### PR TITLE
Fix windows endOfLine error

### DIFF
--- a/ui/.prettierrc.json
+++ b/ui/.prettierrc.json
@@ -3,5 +3,6 @@
   "tabWidth": 2,
   "singleQuote": true,
   "jsxBracketSameLine": true,
-  "printWidth": 80
+  "printWidth": 80,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
### 问题描述：
在 `Windows` 启动 `UI` 前端项目时，`Eslint` 报错 `Delete ␍`

### 问题原因：
由于行尾风格配置导致

### 解决方案：
使用 `auto` 自动匹配风格

### Problem Description:
`Eslint` reports `Delete ␍` error when starting `UI` front-end project on `Windows`

### problem causes:
Due to line ending style configuration

### solution:
Use `auto` to automatically match styles