### PR TITLE
Only allow use pnpm

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -15,7 +15,8 @@
     "prepare": "cd .. && husky install",
     "cz": "cz",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
-    "prettier": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\""
+    "prettier": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
+    "preinstall": "node ./scripts/preinstall.js"
   },
   "config": {
     "commitizen": {

--- a/ui/scripts/preinstall.js
+++ b/ui/scripts/preinstall.js
@@ -1,0 +1,5 @@
+// There is a bug when using npm to install: the execution of preinstall is after install, so when this prompt is displayed, the dependent packages have already been installed.
+if (!/pnpm/.test(process.env.npm_execpath)) {
+    console.warn(`\u001b[33mThis repository requires using pnpm as the package manager for scripts to work properly.\u001b[39m\n`)
+    process.exit(1)
+}


### PR DESCRIPTION
This PR is used to prompt when using yarn or npm or cnpm to install dependencies, only pnpm is supported

But there is a bug when using npm to install: 
the execution of preinstall is after install
so when this prompt is displayed, the dependent packages have already been installed.

has another solution is:
`"preinstall": "npx only-allow pnpm"`, it's use only-allow package be supported by pnpm
This solution has the same bug as above

------------------------------------------
这个 PR 用来在使用 yarn 或 npm 或 cnpm 安装依赖时，进行提示只支持 pnpm

但使用 npm 安装时有一个 bug：
preinstall 的执行是在 install 安装之后
所以当出现这个提示的时候，依赖包其实已经安装好了。（只能起到提示的作用）

还有一个方案是使用 pnpm 提供的包 (only-allow)[https://github.com/pnpm/only-allow]：
```js
// package.json
"scripts": {
    "preinstall": "npx only-allow pnpm"
}
```
这个方案也会出现上面说到的 npm 的 bug