### PR TITLE
Preview Environment for PRs on Answer

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -1,0 +1,98 @@
+name: Build PR Image
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  build-answer:
+    name: Build and push `Answer`
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    if: ${{ github.event.action != 'closed' }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Generate UUID image name
+        id: uuid
+        run: echo "UUID_WORKER=$(uuidgen)" >> $GITHUB_ENV
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: registry.uffizzi.com/${{ env.UUID_WORKER }}
+          tags: |
+            type=raw,value=60d
+
+      - name: Build and Push Image to registry.uffizzi.com - Uffizzi's ephemeral Registry
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha, mode=max
+
+  render-compose-file:
+    name: Render Docker Compose File
+    # Pass output of this workflow to another triggered by `workflow_run` event.
+    runs-on: ubuntu-latest
+    needs:
+      - build-answer
+    outputs:
+      compose-file-cache-key: ${{ steps.hash.outputs.hash }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+      - name: Render Compose File
+        run: |
+          ANSWER_IMAGE=${{ needs.build-answer.outputs.tags }}
+          export ANSWER_IMAGE
+          export UFFIZZI_URL=\$UFFIZZI_URL
+          # Render simple template from environment variables.
+          envsubst < docker-compose.uffizzi.yml > docker-compose.rendered.yml
+          cat docker-compose.rendered.yml
+      - name: Upload Rendered Compose File as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: docker-compose.rendered.yml
+          retention-days: 2
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2
+
+  delete-preview:
+    name: Call for Preview Deletion
+    runs-on: ubuntu-latest
+    if: ${{ github.event.action == 'closed' }}
+    steps:
+      # If this PR is closing, we will not render a compose file nor pass it to the next workflow.
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -1,0 +1,88 @@
+name: Deploy Uffizzi Preview
+
+on:
+  workflow_run:
+    workflows:
+      - "Build PR Image"
+    types:
+      - completed
+
+
+jobs:
+  cache-compose-file:
+    name: Cache Compose File
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      compose-file-cache-key: ${{ env.HASH }}
+      pr-number: ${{ env.PR_NUMBER }}
+    steps:
+      - name: 'Download artifacts'
+        # Fetch output (zip archive) from the workflow run that triggered this workflow.
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "preview-spec"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip preview-spec.zip
+      - name: Read Event into ENV
+        run: |
+          echo 'EVENT_JSON<<EOF' >> $GITHUB_ENV
+          cat event.json >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Hash Rendered Compose File
+        id: hash
+        # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        run: echo "HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_ENV
+      - name: Cache Rendered Compose File
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        uses: actions/cache@v3
+        with:
+          path: docker-compose.rendered.yml
+          key: ${{ env.HASH }}
+
+      - name: Read PR Number From Event Object
+        id: pr
+        run: echo "PR_NUMBER=${{ fromJSON(env.EVENT_JSON).number }}" >> $GITHUB_ENV
+      - name: DEBUG - Print Job Outputs
+        if: ${{ runner.debug }}
+        run: |
+          echo "PR number: ${{ env.PR_NUMBER }}"
+          echo "Compose file hash: ${{ env.HASH }}"
+          cat event.json
+
+  deploy-uffizzi-preview:
+    name: Use Remote Workflow to Preview on Uffizzi
+    needs:
+      - cache-compose-file
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2
+    with:
+      # If this workflow was triggered by a PR close event, cache-key will be an empty string
+      # and this reusable workflow will delete the preview deployment.
+      compose-file-cache-key: ${{ needs.cache-compose-file.outputs.compose-file-cache-key }}
+      compose-file-cache-path: docker-compose.rendered.yml
+      server: https://app.uffizzi.com
+      pr-number: ${{ needs.cache-compose-file.outputs.pr-number }}
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write

--- a/docker-compose.uffizzi.yml
+++ b/docker-compose.uffizzi.yml
@@ -1,0 +1,36 @@
+version: "3"
+
+# uffizzi integration
+x-uffizzi:
+  ingress:
+    service: answer
+    port: 80
+
+services:
+
+  answer:
+    image: "${ANSWER_IMAGE}"
+    volumes:
+      - answer-data:/data
+    deploy:
+      resources:
+        limits:
+          memory: 4000M
+
+  mysql:
+   image: mysql:latest
+   environment:
+    - MYSQL_DATABASE=answer
+    - MYSQL_ROOT_PASSWORD=password
+    - MYSQL_USER=mysql
+    - MYSQL_PASSWORD=mysql
+   volumes:
+      - sql_data:/var/lib/mysql
+   deploy:
+            resources:
+              limits:
+                memory: 500M
+
+volumes:
+  answer-data:
+  sql_data:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR is adding support for **preview environments for PR events** (opened, sync'ed, reopened, etc) powered by [Uffizzi](https://www.uffizzi.com/). 

This PR is using GHA workflows to build and provision the preview environments. Utilizing docker-compose examples from **answer's** repo, the PR uses `docker-compose.uffizzi.yml` to build `answer` from source - this makes sure the latest changes are reflected in the preview. The docker-compose also includes a MySQL instance to persist data. 

Once a PR event is triggered — _PR opened, PR synced, review requested_ — the build workflow will build the image, and the preview workflow will either spin up a new preview or update an existing preview. The previews are ephemeral — so they live for only as long as needed. 

A comment will be posted on the PR containing the URL of the preview environment, allowing contributors and maintainers to easily navigate to the preview. 

Fixes - https://github.com/answerdev/answer/issues/115

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The motivation behind this PR is to **allow maintainers and contributors to approve contributions in half the time with live previews for every pull request**. The idea behind preview environments by Uffizzi is to eliminate friction while testing and approving changes. Since `answer` has multiple components and each component can be interacted with in various ways (QnA → and several features related to QnAs, like upvoting, categorizing, etc), these environments will prove extremely helpful in testing if changes in the UI/API are working as they are supposed to. 

An in-depth study on preview environments can be found [here](https://www.uffizzi.com/preview-environments-guide). Here is another easy read on [where can you use Uffizzi](https://docs.uffizzi.com/use-cases/why-uffizzi/#what-can-i-use-uffizzi-for) inside `answer's` environment.

## How Has This Been Tested?
In order to test this, I have created a [PR](https://github.com/ShrutiC-git/answer/pull/6) against the main branch of my personal fork of `answer`. This triggered the workflow to create a new preview environment - [here](https://app.uffizzi.com/github.com/ShrutiC-git/answer/pull/6) and this [comment](https://github.com/ShrutiC-git/answer/pull/6#issuecomment-1348669078), posted on the PR, takes me to the preview environment.

To log into the above preview environment, use the following credentials:
- username: admin@admin.com
- password: password

Once you are logged in, you will be able to do all you would on a production instance of Answer; create users, confirm users, create tags, etc. 

To test notifications, I started an SMTP server and through the admin console of Answer, passed the server name, username, and password of the server. Upon saving these changes, test emails were sent successfully to the test email and subsequent notifications as well. 

## Navigating Around a New Preview Environment
Once this PR is merged, post that, here is how you could use the new preview environment — when you visit the link in the PR, visit `/install` and choose your desired configuration. This preview comes with MySQL, available at - 
- username: mysql
- password: mysql
- database: answer
- connection string: localhost:3306

After successful installation, you will be able to log into the preview environment using the admin credentials you provided during installation. After setting up the admin, you can also set up other users. 

In case you get a 50x, make sure the app is actually installed by visiting `/install`. This needs to be done every time a new preview environment is spun, which happens when either a PR is closed, a new PR opens or an environment has been marked stale past its expiration time.
****

Looking forward to powering preview environments for Answer, and thereby, making reviewing, testing, releasing easy. Please let me know if there are any questions or if there's anything we can change to make Uffizzi better align with Answer!

cc  @joyqi @waveywaves