### PR TITLE
fix: 在使用标签同义词的时候，发现如果将 B 设置为 A 的同义词，那么之前绑定了 B 标签的问题将无法找到，通过索引 A 标签的方式

### DIFF
--- a/internal/repo/question/question_repo.go
+++ b/internal/repo/question/question_repo.go
@@ -206,16 +206,14 @@ func (qr *questionRepo) GetQuestionIDsPage(ctx context.Context, page, pageSize i
 }
 
 // GetQuestionPage query question page
-func (qr *questionRepo) GetQuestionPage(ctx context.Context, page, pageSize int, userID, tagID, orderCond string) (
+func (qr *questionRepo) GetQuestionPage(ctx context.Context, page, pageSize int, userID string, tagIDs []string, orderCond string) (
 	questionList []*entity.Question, total int64, err error) {
 	questionList = make([]*entity.Question, 0)
 
 	session := qr.data.DB.Where("question.status = ? OR question.status = ?",
 		entity.QuestionStatusAvailable, entity.QuestionStatusClosed)
-	if len(tagID) > 0 {
-		session.Join("LEFT", "tag_rel", "question.id = tag_rel.object_id")
-		session.And("tag_rel.tag_id = ?", tagID)
-		session.And("tag_rel.status = ?", entity.TagRelStatusAvailable)
+	if len(tagIDs) > 0 {
+		session.Where(builder.In("id", builder.Select("object_id").From("tag_rel").And(builder.Eq{"status": entity.TagRelStatusAvailable}).Where(builder.In("tag_id", tagIDs))))
 	}
 	if len(userID) > 0 {
 		session.And("question.user_id = ?", userID)

--- a/internal/repo/tag_common/tag_common_repo.go
+++ b/internal/repo/tag_common/tag_common_repo.go
@@ -116,6 +116,20 @@ func (tr *tagCommonRepo) GetTagListByNames(ctx context.Context, names []string) 
 	return
 }
 
+// GetTagListByMainTagID get tag list by main tag
+func (tr *tagCommonRepo) GetTagListByMainTagID(ctx context.Context, id string) (tagList []*entity.Tag, err error) {
+	tagList = make([]*entity.Tag, 0)
+	cond := &entity.Tag{}
+	session := tr.data.DB.Where("main_tag_id = ?", id)
+	session.Where(builder.Eq{"status": entity.TagStatusAvailable})
+	session.Asc("slug_name")
+	err = session.OrderBy("recommend desc,reserved desc,id desc").Find(&tagList, cond)
+	if err != nil {
+		err = errors.InternalServer(reason.DatabaseError).WithError(err).WithStack()
+	}
+	return
+}
+
 // GetTagByID get tag one
 func (tr *tagCommonRepo) GetTagByID(ctx context.Context, tagID string, includeDeleted bool) (
 	tag *entity.Tag, exist bool, err error,

--- a/internal/schema/question_schema.go
+++ b/internal/schema/question_schema.go
@@ -240,9 +240,9 @@ type QuestionPageReq struct {
 	Tag       string `validate:"omitempty,gt=0,lte=100" form:"tag"`
 	Username  string `validate:"omitempty,gt=0,lte=100" form:"username"`
 
-	LoginUserID      string `json:"-"`
-	UserIDBeSearched string `json:"-"`
-	TagID            string `json:"-"`
+	LoginUserID      string   `json:"-"`
+	UserIDBeSearched string   `json:"-"`
+	TagIDs           []string `json:"-"`
 }
 
 const (

--- a/internal/service/question_common/question.go
+++ b/internal/service/question_common/question.go
@@ -31,7 +31,7 @@ type QuestionRepo interface {
 	UpdateQuestion(ctx context.Context, question *entity.Question, Cols []string) (err error)
 	GetQuestion(ctx context.Context, id string) (question *entity.Question, exist bool, err error)
 	GetQuestionList(ctx context.Context, question *entity.Question) (questions []*entity.Question, err error)
-	GetQuestionPage(ctx context.Context, page, pageSize int, userID, tagID, orderCond string) (
+	GetQuestionPage(ctx context.Context, page, pageSize int, userID string, tagIDs []string, orderCond string) (
 		questionList []*entity.Question, total int64, err error)
 	UpdateQuestionStatus(ctx context.Context, question *entity.Question) (err error)
 	SearchByTitleLike(ctx context.Context, title string) (questionList []*entity.Question, err error)

--- a/internal/service/question_service.go
+++ b/internal/service/question_service.go
@@ -888,7 +888,20 @@ func (qs *QuestionService) GetQuestionPage(ctx context.Context, req *schema.Ques
 			return nil, 0, err
 		}
 		if exist {
-			req.TagID = tagInfo.ID
+			tagIDs := make([]string, 0)
+			tagIDs = append(tagIDs, tagInfo.ID)
+			mainTagID := tagInfo.ID
+			if tagInfo.MainTagID != 0 {
+				mainTagID = fmt.Sprintf("%d", tagInfo.MainTagID)
+			}
+			tags, err := qs.tagCommon.GetTagListByMainTagID(ctx, mainTagID)
+			if err != nil {
+				return nil, 0, err
+			}
+			for _, tag := range tags {
+				tagIDs = append(tagIDs, tag.ID)
+			}
+			req.TagIDs = tagIDs
 		}
 	}
 
@@ -905,7 +918,7 @@ func (qs *QuestionService) GetQuestionPage(ctx context.Context, req *schema.Ques
 	}
 
 	questionList, total, err := qs.questionRepo.GetQuestionPage(ctx, req.Page, req.PageSize,
-		req.UserIDBeSearched, req.TagID, req.OrderCond)
+		req.UserIDBeSearched, req.TagIDs, req.OrderCond)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/service/tag_common/tag_common.go
+++ b/internal/service/tag_common/tag_common.go
@@ -26,6 +26,7 @@ type TagCommonRepo interface {
 	GetTagBySlugName(ctx context.Context, slugName string) (tagInfo *entity.Tag, exist bool, err error)
 	GetTagListByName(ctx context.Context, name string, hasReserved bool) (tagList []*entity.Tag, err error)
 	GetTagListByNames(ctx context.Context, names []string) (tagList []*entity.Tag, err error)
+	GetTagListByMainTagID(ctx context.Context, id string) (tagList []*entity.Tag, err error)
 	GetTagByID(ctx context.Context, tagID string, includeDeleted bool) (tag *entity.Tag, exist bool, err error)
 	GetTagPage(ctx context.Context, page, pageSize int, tag *entity.Tag, queryCond string) (tagList []*entity.Tag, total int64, err error)
 	GetRecommendTagList(ctx context.Context) (tagList []*entity.Tag, err error)
@@ -104,6 +105,16 @@ func (ts *TagCommonService) GetSiteWriteRecommendTag(ctx context.Context) (tags 
 		tags = append(tags, item.SlugName)
 	}
 	return tags, nil
+}
+
+// GetTagListByMainTagID get object tag
+func (ts *TagCommonService) GetTagListByMainTagID(ctx context.Context, id string) (tagList []*entity.Tag, err error) {
+	tagList, err = ts.tagCommonRepo.GetTagListByMainTagID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	ts.TagsFormatRecommendAndReserved(ctx, tagList)
+	return
 }
 
 func (ts *TagCommonService) SetSiteWriteTag(ctx context.Context, recommendTags, reservedTags []string, userID string) (


### PR DESCRIPTION
thanks!