### PR TITLE
fix: tests failing during compilation

### DIFF
--- a/internal/repo/repo_test/comment_repo_test.go
+++ b/internal/repo/repo_test/comment_repo_test.go
@@ -65,7 +65,7 @@ func Test_commentRepo_UpdateComment(t *testing.T) {
 	assert.NoError(t, err)
 
 	testCommentEntity.ParsedText = "test"
-	err = commentRepo.UpdateCommentContent(context.TODO(), testCommentEntity, "", "")
+	err = commentRepo.UpdateCommentContent(context.TODO(), testCommentEntity.ID, "test", "test")
 	assert.NoError(t, err)
 
 	newComment, exist, err := commonCommentRepo.GetComment(context.TODO(), testCommentEntity.ID)

--- a/internal/repo/repo_test/tag_repo_test.go
+++ b/internal/repo/repo_test/tag_repo_test.go
@@ -93,7 +93,7 @@ func Test_tagRepo_GetTagListByName(t *testing.T) {
 	tagOnce.Do(addTagList)
 	tagCommonRepo := tag_common.NewTagCommonRepo(testDataSource, unique.NewUniqueIDRepo(testDataSource))
 
-	gotTags, err := tagCommonRepo.GetTagListByName(context.TODO(), testTagList[0].SlugName, false)
+	gotTags, err := tagCommonRepo.GetTagListByName(context.TODO(), testTagList[0].SlugName, false, false)
 	assert.NoError(t, err)
 	assert.Equal(t, testTagList[0].SlugName, gotTags[0].SlugName)
 }


### PR DESCRIPTION
- `commentRepo.UpdateCommentContent` function should be called with `ParsedText = test`
- `tagCommonRepo.GetTagListByName` function's signature has changed since - this PR modifies the same in tests