### PR TITLE
Fix Dropped Vote Service Errors

### DIFF
--- a/.vaunt/config.yaml
+++ b/.vaunt/config.yaml
@@ -6,7 +6,7 @@ achievements:
       description: Awarded for bringing up enhancement, dream big!
       triggers:
         - trigger:
-            actor: author
+            actor: assignees
             action: issue
             condition: labels in ['enhancement'] & labels in ['LGTM']
   - achievement:
@@ -15,6 +15,6 @@ achievements:
       description: Awarded for identifying real bugs, well spotted!
       triggers:
         - trigger:
-            actor: author
+            actor: assignees
             action: issue
             condition: labels in ['bug'] & labels in ['LGTM']

--- a/internal/service/vote_service.go
+++ b/internal/service/vote_service.go
@@ -124,6 +124,9 @@ func (vs *VoteService) VoteDown(ctx context.Context, req *schema.VoteReq) (resp 
 	voteDownOperationInfo := vs.createVoteOperationInfo(ctx, req.UserID, false, objectInfo)
 	if req.IsCancel {
 		err = vs.voteRepo.CancelVote(ctx, voteDownOperationInfo)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		// cancel vote up if exist
 		err = vs.voteRepo.CancelVote(ctx, vs.createVoteOperationInfo(ctx, req.UserID, true, objectInfo))
@@ -131,6 +134,9 @@ func (vs *VoteService) VoteDown(ctx context.Context, req *schema.VoteReq) (resp 
 			return nil, err
 		}
 		err = vs.voteRepo.Vote(ctx, voteDownOperationInfo)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	resp = &schema.VoteResp{}


### PR DESCRIPTION
This picks up two dropped `err` variables in the `internal/service` package.