### PR TITLE
better way to decode images

### DIFF
--- a/pkg/checker/file_type.go
+++ b/pkg/checker/file_type.go
@@ -12,12 +12,14 @@ func IsSupportedImageFile(file io.Reader, ext string) bool {
 	ext = strings.TrimPrefix(ext, ".")
 	var err error
 	switch strings.ToUpper(ext) {
-	case "JPG", "JPEG":
+	case "JPEG":
 		_, err = jpeg.Decode(file)
 	case "PNG":
 		_, err = png.Decode(file)
 	case "ICO":
 		// TODO: There is currently no good Golang library to parse whether the image is in ico format.
+		return true
+	case "JPG":
 		return true
 	default:
 		return false

--- a/pkg/checker/file_type.go
+++ b/pkg/checker/file_type.go
@@ -1,25 +1,24 @@
 package checker
 
 import (
-	"image/jpeg"
-	"image/png"
+	"image"
+	_ "image/gif" // use init to support decode jpeg,jpg,png,gif
+	_ "image/jpeg"
+	_ "image/png"
 	"io"
 	"strings"
 )
 
-// IsSupportedImageFile currently answers support image type is `image/jpeg,image/jpg,image/png`
+// IsSupportedImageFile currently answers support image type is `image/jpeg,image/jpg,image/png, image/gif`
 func IsSupportedImageFile(file io.Reader, ext string) bool {
+
 	ext = strings.TrimPrefix(ext, ".")
 	var err error
 	switch strings.ToUpper(ext) {
-	case "JPEG":
-		_, err = jpeg.Decode(file)
-	case "PNG":
-		_, err = png.Decode(file)
+	case "JPG", "JPEG", "PNG", "GIF": // only allow for `image/jpeg,image/jpg,image/png, image/gif`
+		_, _, err = image.Decode(file)
 	case "ICO":
 		// TODO: There is currently no good Golang library to parse whether the image is in ico format.
-		return true
-	case "JPG":
 		return true
 	default:
 		return false


### PR DESCRIPTION
In the past, answer use postfix of file to choose decoder
now, we init the decoder of image, and use image.decode, it will ignore the postfix 