### PR TITLE
fix: failed to build plugins in windows

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -484,6 +484,7 @@ func copyDirEntries(sourceFs fs.FS, sourceDir, targetDir string, ignoreDir ...st
 
 		// Construct the absolute path for the source file/directory
 		srcPath := filepath.Join(sourceDir, path)
+		srcPath = filepath.ToSlash(srcPath)
 
 		// Construct the absolute path for the destination file/directory
 		dstPath := filepath.Join(targetDir, path)


### PR DESCRIPTION
Close #1376.

Issue caused by restrictions for `sourceFs.Open(srcPath)`.
<img width="1376" height="530" alt="image" src="https://github.com/user-attachments/assets/34be0861-ce86-4824-8eae-966f8628c34c" />


Succeeded to build in Windows.
<img width="1360" height="524" alt="image" src="https://github.com/user-attachments/assets/e7298faf-c301-476f-b2bc-03dfa2d87fb0" />
