### PR TITLE
fix: multi byte run boundary for cut long title

### DIFF
--- a/pkg/htmltext/htmltext.go
+++ b/pkg/htmltext/htmltext.go
@@ -96,10 +96,16 @@ func convertChinese(content string) string {
 }
 
 func cutLongTitle(title string) string {
-	if len(title) > 150 {
-		return title[0:150]
+	maxBytes := 150
+	if len(title) <= maxBytes {
+		return title
 	}
-	return title
+
+	truncated := title[:maxBytes]
+	for len(truncated) > 0 && !utf8.ValidString(truncated) {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return truncated
 }
 
 // FetchExcerpt return the excerpt from the HTML string

--- a/pkg/htmltext/htmltext_test.go
+++ b/pkg/htmltext/htmltext_test.go
@@ -21,6 +21,7 @@ package htmltext
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -176,6 +177,27 @@ func TestFetchRangedExcerpt(t *testing.T) {
 	expected = "...你好😂world"
 	actual = FetchRangedExcerpt("<p>hello你好😂world</p>", "...", 5, 100)
 	assert.Equal(t, expected, actual)
+}
+
+func TestCutLongTitle(t *testing.T) {
+	// Short title, no cutting needed
+	short := "hello"
+	assert.Equal(t, short, cutLongTitle(short))
+
+	// Exactly max bytes, no cutting needed
+	exact150 := strings.Repeat("a", 150)
+	assert.Equal(t, 150, len(cutLongTitle(exact150)))
+
+	// Just over max bytes, should be cut
+	exact151 := strings.Repeat("a", 151)
+	assert.Equal(t, 150, len(cutLongTitle(exact151)))
+
+	// Multi-byte rune at boundary gets removed properly
+	asciiPart := strings.Repeat("a", 149) // 149 bytes
+	multiByteChar := "中"                  // 3 bytes - will span bytes 149-151
+	title := asciiPart + multiByteChar    // 152 bytes total
+
+	assert.Equal(t, asciiPart, cutLongTitle(title))
 }
 
 func TestFetchMatchedExcerpt(t *testing.T) {


### PR DESCRIPTION
Multi-byte rune at boundary gets corrupted:
* A string where a multi-byte character spans the 150-byte boundary
* Chinese character "中" is 3 bytes (0xE4 0xB8 0xAD)
* If we have 149 ASCII chars + "中", the "中" starts at byte 149 and ends at byte 151
* cutLongTitle should cut before "中", returning 149 bytes
* But the current implementation returns 150 bytes, cutting "中" in half and making string invalid
