### PR TITLE
Initialize server port from INSTALL_PORT environment variable if provided

### DIFF
--- a/internal/install/install_controller.go
+++ b/internal/install/install_controller.go
@@ -191,6 +191,13 @@ func InitEnvironment(ctx *gin.Context) {
 	c.I18n.BundleDir = path.I18nPath
 	c.ServiceConfig.UploadPath = path.UploadFilePath
 
+	// Set server port from INSTALL_PORT environment variable if provided
+	installPort := os.Getenv("INSTALL_PORT")
+	if len(installPort) > 0 {
+		c.Server.HTTP.Addr = "0.0.0.0:" + installPort
+		c.Swaggerui.Address = ":" + installPort
+	}
+
 	if err := conf.RewriteConfig(confPath, c); err != nil {
 		log.Errorf("rewrite config failed %s", err)
 		handler.HandleResponse(ctx, errors.BadRequest(reason.ReadConfigFailed), nil)


### PR DESCRIPTION
If helm chart was deployed to use a non privileged port Apache Answer wrote wrong port (always 80) into config file. Then the pod restarted which ended in a crash loop as non-root users may not open privileged ports.

Fixes #1438 
