### PR TITLE
fix: get right lang

### DIFF
--- a/internal/base/handler/handler.go
+++ b/internal/base/handler/handler.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/apache/answer/internal/base/constant"
 	"github.com/apache/answer/internal/base/reason"
 	"github.com/apache/answer/internal/base/validator"
 	"github.com/gin-gonic/gin"
@@ -33,7 +32,7 @@ import (
 
 // HandleResponse Handle response body
 func HandleResponse(ctx *gin.Context, err error, data any) {
-	lang := GetLang(ctx)
+	lang := GetLangByCtx(ctx)
 	// no error
 	if err == nil {
 		ctx.JSON(http.StatusOK, NewRespBodyData(http.StatusOK, reason.Success, data).TrMsg(lang))
@@ -63,8 +62,7 @@ func HandleResponse(ctx *gin.Context, err error, data any) {
 
 // BindAndCheck bind request and check
 func BindAndCheck(ctx *gin.Context, data any) bool {
-	lang := GetLang(ctx)
-	ctx.Set(constant.AcceptLanguageFlag, lang)
+	lang := GetLangByCtx(ctx)
 	if err := ctx.ShouldBind(data); err != nil {
 		log.Errorf("http_handle BindAndCheck fail, %s", err.Error())
 		HandleResponse(ctx, myErrors.New(http.StatusBadRequest, reason.RequestFormatError), nil)
@@ -81,7 +79,7 @@ func BindAndCheck(ctx *gin.Context, data any) bool {
 
 // BindAndCheckReturnErr bind request and check
 func BindAndCheckReturnErr(ctx *gin.Context, data any) (errFields []*validator.FormErrorField) {
-	lang := GetLang(ctx)
+	lang := GetLangByCtx(ctx)
 	if err := ctx.ShouldBind(data); err != nil {
 		log.Errorf("http_handle BindAndCheck fail, %s", err.Error())
 		HandleResponse(ctx, myErrors.New(http.StatusBadRequest, reason.RequestFormatError), nil)

--- a/internal/base/handler/lang.go
+++ b/internal/base/handler/lang.go
@@ -23,18 +23,8 @@ import (
 	"context"
 
 	"github.com/apache/answer/internal/base/constant"
-	"github.com/gin-gonic/gin"
 	"github.com/segmentfault/pacman/i18n"
 )
-
-// GetLang get language from header
-func GetLang(ctx *gin.Context) i18n.Language {
-	acceptLanguage := ctx.GetHeader(constant.AcceptLanguageFlag)
-	if len(acceptLanguage) == 0 {
-		return i18n.DefaultLanguage
-	}
-	return i18n.Language(acceptLanguage)
-}
 
 // GetLangByCtx get language from header
 func GetLangByCtx(ctx context.Context) i18n.Language {

--- a/internal/base/middleware/accept_language.go
+++ b/internal/base/middleware/accept_language.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/apache/answer/internal/base/constant"
-	"github.com/apache/answer/internal/base/handler"
 	"github.com/apache/answer/internal/base/translator"
 	"github.com/gin-gonic/gin"
 	"github.com/segmentfault/pacman/i18n"
@@ -33,8 +32,8 @@ import (
 // ExtractAndSetAcceptLanguage extract accept language from header and set to context
 func ExtractAndSetAcceptLanguage(ctx *gin.Context) {
 	// The language of our front-end configuration, like en_US
-	lang := handler.GetLang(ctx)
-	tag, _, err := language.ParseAcceptLanguage(string(lang))
+	acceptLanguage := ctx.GetHeader(constant.AcceptLanguageFlag)
+	tag, _, err := language.ParseAcceptLanguage(acceptLanguage)
 	if err != nil || len(tag) == 0 {
 		ctx.Set(constant.AcceptLanguageFlag, i18n.LanguageEnglish)
 		return

--- a/internal/controller/answer_controller.go
+++ b/internal/controller/answer_controller.go
@@ -89,7 +89,7 @@ func (ac *AnswerController) RemoveAnswer(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return
@@ -225,7 +225,7 @@ func (ac *AnswerController) AddAnswer(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return
@@ -325,7 +325,7 @@ func (ac *AnswerController) UpdateAnswer(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return

--- a/internal/controller/comment_controller.go
+++ b/internal/controller/comment_controller.go
@@ -106,7 +106,7 @@ func (cc *CommentController) AddComment(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return
@@ -154,7 +154,7 @@ func (cc *CommentController) RemoveComment(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return
@@ -215,7 +215,7 @@ func (cc *CommentController) UpdateComment(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return

--- a/internal/controller/lang_controller.go
+++ b/internal/controller/lang_controller.go
@@ -48,7 +48,7 @@ func NewLangController(tr i18n.Translator, siteInfoService siteinfo_common.SiteI
 // @Success 200 {object} handler.RespBody{}
 // @Router /answer/api/v1/language/config [get]
 func (u *LangController) GetLangMapping(ctx *gin.Context) {
-	data, _ := u.translator.Dump(handler.GetLang(ctx))
+	data, _ := u.translator.Dump(handler.GetLangByCtx(ctx))
 	var resp map[string]any
 	_ = json.Unmarshal(data, &resp)
 	handler.HandleResponse(ctx, nil, resp)

--- a/internal/controller/question_controller.go
+++ b/internal/controller/question_controller.go
@@ -94,7 +94,7 @@ func (qc *QuestionController) RemoveQuestion(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return
@@ -419,7 +419,7 @@ func (qc *QuestionController) AddQuestion(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return
@@ -445,7 +445,7 @@ func (qc *QuestionController) AddQuestion(ctx *gin.Context) {
 		return
 	}
 	if !req.CanAddTag && hasNewTag {
-		lang := handler.GetLang(ctx)
+		lang := handler.GetLangByCtx(ctx)
 		msg := translator.TrWithData(lang, reason.NoEnoughRankToOperate, &schema.PermissionTrTplData{Rank: requireRanks[6]})
 		handler.HandleResponse(ctx, errors.Forbidden(reason.NoEnoughRankToOperate).WithMsg(msg), nil)
 		return
@@ -524,7 +524,7 @@ func (qc *QuestionController) AddQuestionByAnswer(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return
@@ -646,7 +646,7 @@ func (qc *QuestionController) UpdateQuestion(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return
@@ -681,7 +681,7 @@ func (qc *QuestionController) UpdateQuestion(ctx *gin.Context) {
 		return
 	}
 	if !req.CanAddTag && hasNewTag {
-		lang := handler.GetLang(ctx)
+		lang := handler.GetLangByCtx(ctx)
 		msg := translator.TrWithData(lang, reason.NoEnoughRankToOperate, &schema.PermissionTrTplData{Rank: requireRanks[4]})
 		handler.HandleResponse(ctx, errors.Forbidden(reason.NoEnoughRankToOperate).WithMsg(msg), nil)
 		return
@@ -765,7 +765,7 @@ func (qc *QuestionController) UpdateQuestionInviteUser(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return

--- a/internal/controller/report_controller.go
+++ b/internal/controller/report_controller.go
@@ -79,7 +79,7 @@ func (rc *ReportController) AddReport(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return

--- a/internal/controller/search_controller.go
+++ b/internal/controller/search_controller.go
@@ -78,7 +78,7 @@ func (sc *SearchController) Search(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -206,7 +206,7 @@ func (tc *TemplateController) QuestionList(ctx *gin.Context) {
 	UrlUseTitle := siteInfo.SiteSeo.Permalink == constant.PermalinkQuestionIDAndTitle ||
 		siteInfo.SiteSeo.Permalink == constant.PermalinkQuestionIDAndTitleByShortID
 
-	siteInfo.Title = fmt.Sprintf("%s - %s", translator.Tr(handler.GetLang(ctx), constant.QuestionsTitleTrKey), siteInfo.General.Name)
+	siteInfo.Title = fmt.Sprintf("%s - %s", translator.Tr(handler.GetLangByCtx(ctx), constant.QuestionsTitleTrKey), siteInfo.General.Name)
 	tc.html(ctx, http.StatusOK, "question.html", siteInfo, gin.H{
 		"data":        data,
 		"useTitle":    UrlUseTitle,
@@ -461,7 +461,7 @@ func (tc *TemplateController) TagList(ctx *gin.Context) {
 	if req.Page > 1 {
 		siteInfo.Canonical = fmt.Sprintf("%s/tags?page=%d", siteInfo.General.SiteUrl, req.Page)
 	}
-	siteInfo.Title = fmt.Sprintf("%s - %s", translator.Tr(handler.GetLang(ctx), constant.TagsListTitleTrKey), siteInfo.General.Name)
+	siteInfo.Title = fmt.Sprintf("%s - %s", translator.Tr(handler.GetLangByCtx(ctx), constant.TagsListTitleTrKey), siteInfo.General.Name)
 	tc.html(ctx, http.StatusOK, "tags.html", siteInfo, gin.H{
 		"page": page,
 		"data": data,
@@ -492,14 +492,14 @@ func (tc *TemplateController) TagInfo(ctx *gin.Context) {
 	}
 	siteInfo.Description = htmltext.FetchExcerpt(tagInfo.ParsedText, "...", 240)
 	if len(tagInfo.ParsedText) == 0 {
-		siteInfo.Description = translator.Tr(handler.GetLang(ctx), constant.TagHasNoDescription)
+		siteInfo.Description = translator.Tr(handler.GetLangByCtx(ctx), constant.TagHasNoDescription)
 	}
 	siteInfo.Keywords = tagInfo.DisplayName
 
 	UrlUseTitle := siteInfo.SiteSeo.Permalink == constant.PermalinkQuestionIDAndTitle ||
 		siteInfo.SiteSeo.Permalink == constant.PermalinkQuestionIDAndTitleByShortID
 
-	siteInfo.Title = fmt.Sprintf("'%s' %s - %s", tagInfo.DisplayName, translator.Tr(handler.GetLang(ctx), constant.QuestionsTitleTrKey), siteInfo.General.Name)
+	siteInfo.Title = fmt.Sprintf("'%s' %s - %s", tagInfo.DisplayName, translator.Tr(handler.GetLangByCtx(ctx), constant.QuestionsTitleTrKey), siteInfo.General.Name)
 	tc.html(ctx, http.StatusOK, "tag-detail.html", siteInfo, gin.H{
 		"tag":           tagInfo,
 		"questionList":  questionList,
@@ -597,7 +597,7 @@ func (tc *TemplateController) html(ctx *gin.Context, code int, tpl string, siteI
 		data["title"] = siteInfo.General.Name
 	}
 	data["description"] = siteInfo.Description
-	data["language"] = handler.GetLang(ctx)
+	data["language"] = handler.GetLangByCtx(ctx)
 	data["timezone"] = siteInfo.Interface.TimeZone
 	language := strings.ReplaceAll(siteInfo.Interface.Language, "_", "-")
 	data["lang"] = language

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -142,7 +142,7 @@ func (uc *UserController) UserEmailLogin(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return
@@ -154,7 +154,7 @@ func (uc *UserController) UserEmailLogin(ctx *gin.Context) {
 		uc.actionService.ActionRecordAdd(ctx, entity.CaptchaActionPassword, ctx.ClientIP())
 		errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 			ErrorField: "e_mail",
-			ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.EmailOrPasswordWrong),
+			ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.EmailOrPasswordWrong),
 		})
 		handler.HandleResponse(ctx, errors.BadRequest(reason.EmailOrPasswordWrong), errFields)
 		return
@@ -191,7 +191,7 @@ func (uc *UserController) RetrievePassWord(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return
@@ -286,7 +286,7 @@ func (uc *UserController) UserRegisterByEmail(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return
@@ -297,7 +297,7 @@ func (uc *UserController) UserRegisterByEmail(ctx *gin.Context) {
 	if len(errFields) > 0 {
 		for _, field := range errFields {
 			field.ErrorMsg = translator.
-				Tr(handler.GetLang(ctx), field.ErrorMsg)
+				Tr(handler.GetLangByCtx(ctx), field.ErrorMsg)
 		}
 		handler.HandleResponse(ctx, err, errFields)
 	} else {
@@ -364,7 +364,7 @@ func (uc *UserController) UserVerifyEmailSend(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return
@@ -399,7 +399,7 @@ func (uc *UserController) UserModifyPassWord(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return
@@ -415,7 +415,7 @@ func (uc *UserController) UserModifyPassWord(ctx *gin.Context) {
 	if !oldPassVerification {
 		errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 			ErrorField: "old_pass",
-			ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.OldPasswordVerificationFailed),
+			ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.OldPasswordVerificationFailed),
 		})
 		handler.HandleResponse(ctx, errors.BadRequest(reason.OldPasswordVerificationFailed), errFields)
 		return
@@ -424,7 +424,7 @@ func (uc *UserController) UserModifyPassWord(ctx *gin.Context) {
 	if req.OldPass == req.Pass {
 		errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 			ErrorField: "pass",
-			ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.NewPasswordSameAsPreviousSetting),
+			ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.NewPasswordSameAsPreviousSetting),
 		})
 		handler.HandleResponse(ctx, errors.BadRequest(reason.NewPasswordSameAsPreviousSetting), errFields)
 		return
@@ -456,7 +456,7 @@ func (uc *UserController) UserUpdateInfo(ctx *gin.Context) {
 	req.IsAdmin = middleware.GetUserIsAdminModerator(ctx)
 	errFields, err := uc.userService.UpdateInfo(ctx, req)
 	for _, field := range errFields {
-		field.ErrorMsg = translator.Tr(handler.GetLang(ctx), field.ErrorMsg)
+		field.ErrorMsg = translator.Tr(handler.GetLangByCtx(ctx), field.ErrorMsg)
 	}
 	handler.HandleResponse(ctx, err, errFields)
 }
@@ -587,7 +587,7 @@ func (uc *UserController) UserChangeEmailSendCode(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return

--- a/internal/controller/vote_controller.go
+++ b/internal/controller/vote_controller.go
@@ -79,7 +79,7 @@ func (vc *VoteController) VoteUp(ctx *gin.Context) {
 		return
 	}
 	if !can {
-		lang := handler.GetLang(ctx)
+		lang := handler.GetLangByCtx(ctx)
 		msg := translator.TrWithData(lang, reason.NoEnoughRankToOperate, &schema.PermissionTrTplData{Rank: needRank})
 		handler.HandleResponse(ctx, errors.Forbidden(reason.NoEnoughRankToOperate).WithMsg(msg), nil)
 		return
@@ -91,7 +91,7 @@ func (vc *VoteController) VoteUp(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return
@@ -134,7 +134,7 @@ func (vc *VoteController) VoteDown(ctx *gin.Context) {
 		return
 	}
 	if !can {
-		lang := handler.GetLang(ctx)
+		lang := handler.GetLangByCtx(ctx)
 		msg := translator.TrWithData(lang, reason.NoEnoughRankToOperate, &schema.PermissionTrTplData{Rank: needRank})
 		handler.HandleResponse(ctx, errors.Forbidden(reason.NoEnoughRankToOperate).WithMsg(msg), nil)
 		return
@@ -145,7 +145,7 @@ func (vc *VoteController) VoteDown(ctx *gin.Context) {
 		if !captchaPass {
 			errFields := append([]*validator.FormErrorField{}, &validator.FormErrorField{
 				ErrorField: "captcha_code",
-				ErrorMsg:   translator.Tr(handler.GetLang(ctx), reason.CaptchaVerificationFailed),
+				ErrorMsg:   translator.Tr(handler.GetLangByCtx(ctx), reason.CaptchaVerificationFailed),
 			})
 			handler.HandleResponse(ctx, errors.BadRequest(reason.CaptchaVerificationFailed), errFields)
 			return

--- a/internal/controller_admin/user_backyard_controller.go
+++ b/internal/controller_admin/user_backyard_controller.go
@@ -177,7 +177,7 @@ func (uc *UserAdminController) EditUserProfile(ctx *gin.Context) {
 
 	errFields, err := uc.userService.EditUserProfile(ctx, req)
 	for _, field := range errFields {
-		field.ErrorMsg = translator.Tr(handler.GetLang(ctx), field.ErrorMsg)
+		field.ErrorMsg = translator.Tr(handler.GetLangByCtx(ctx), field.ErrorMsg)
 	}
 	handler.HandleResponse(ctx, err, errFields)
 }

--- a/internal/service/importer/importer_service.go
+++ b/internal/service/importer/importer_service.go
@@ -135,7 +135,7 @@ func (ip *ImporterService) ImportQuestion(ctx context.Context, questionInfo plug
 		return err
 	}
 	if !req.CanAddTag && hasNewTag {
-		lang := handler.GetLang(ctx.(*gin.Context))
+		lang := handler.GetLangByCtx(ctx.(*gin.Context))
 		msg := translator.TrWithData(lang, reason.NoEnoughRankToOperate, &schema.PermissionTrTplData{Rank: requireRanks[6]})
 		log.Errorf("error: %v", msg)
 		return errors.BadRequest(msg)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -216,7 +216,7 @@ func (m *statusManager) UnmarshalJSON(data []byte) error {
 
 // Translate translates the key to the current language of the context
 func Translate(ctx *GinContext, key string) string {
-	return translator.Tr(handler.GetLang(ctx), key)
+	return translator.Tr(handler.GetLangByCtx(ctx), key)
 }
 
 // TranslateWithData translates the key to the language with data


### PR DESCRIPTION
handler.GetLang(internal/base/handler/lang.go) is a err usage? or old usage? 
new usage should be GetLangByCtx.
I has check all call, thant i think the right way is call GetLangByCtx but not GetLang,
for middleware of ExtractAndSetAcceptLanguage has registerd.