### PR TITLE
feat(build): simplify new build via config file (ignore CLI args)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 /.idea
 /.fleet
 /.vscode/*.log
+/answer_build*/
+/answer.build.yaml
 /cmd/answer/*.sh
 /cmd/answer/answer
 /cmd/answer/uploads/*

--- a/answer.build.yaml.example
+++ b/answer.build.yaml.example
@@ -1,0 +1,14 @@
+# use buildDir or buildAbsDir
+buildDir: "../answer-builds/build"
+buildAbsDir: ""
+# default new_answer
+outputPath: "new_answer"
+# default the github repository
+answerModule: ""
+plugins:
+    - "github.com/apache/answer-plugins/connector-basic@latest"
+    - "github.com/apache/answer-plugins/reviewer-basic@latest"
+    - "github.com/apache/answer-plugins/captcha-basic@latest"
+    - "github.com/apache/answer-plugins/quick-links@latest"
+# whether if you want to reserve buildDir, default is delete it
+reserveBuild: false

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/apache/answer/internal/base/conf"
 	"github.com/apache/answer/internal/base/path"
@@ -40,6 +39,8 @@ var (
 	dataDirPath string
 	// dumpDataPath dump data path
 	dumpDataPath string
+	// build config path, if exists, ignore other build args
+	buildConfigPath string
 	// place to build new answer
 	buildDir string
 	// plugins needed to build in answer application
@@ -67,6 +68,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&dataDirPath, "data-path", "C", "/data/", "data path, eg: -C ./data/")
 
 	dumpCmd.Flags().StringVarP(&dumpDataPath, "path", "p", "./", "dump data path, eg: -p ./dump/data/")
+
+	buildCmd.Flags().StringVarP(&buildConfigPath, "config", "c", "", "build config path, if exists, ignore other build args")
 
 	buildCmd.Flags().StringSliceVarP(&buildWithPlugins, "with", "w", []string{}, "plugins needed to build")
 
@@ -222,8 +225,7 @@ To run answer, use:
 		Short: "Build Answer with plugins",
 		Long:  `Build a new Answer with plugins that you need`,
 		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Printf("try to build a new answer with plugins:\n%s\n", strings.Join(buildWithPlugins, "\n"))
-			err := cli.BuildNewAnswer(buildDir, buildOutput, buildWithPlugins, cli.OriginalAnswerInfo{
+			err := cli.BuildNewAnswer(buildConfigPath, buildDir, buildOutput, buildWithPlugins, cli.OriginalAnswerInfo{
 				Version:  Version,
 				Revision: Revision,
 				Time:     Time,


### PR DESCRIPTION
## use `./answer build -c answer.build.yaml ` .

``` yaml
# use buildDir or buildAbsDir
buildDir: "../answer-builds/build"
#buildAbsDir: ""
# default new_answer
outputPath: "new_answer"
# default the github repository
answerModule: "./"
plugins:
  - "github.com/apache/answer-plugins/connector-basic@latest"
  - "github.com/apache/answer-plugins/reviewer-basic@latest"
  - "github.com/apache/answer-plugins/captcha-basic@latest"
  - "github.com/apache/answer-plugins/quick-links@latest"
# if you want to reserve product, default is delete it
reserveBuild: true
```

## but not 
```bash
ANSWER_MODUL=xxx   ./answer build  -b ../answer-builds/build  -o new_answer \
-w github.com/apache/answer-plugins/connector-basic@latest \
-w github.com/apache/answer-plugins/reviewer-basic@latest \
-w github.com/apache/answer-plugins/captcha-basic@latest \
-w github.com/apache/answer-plugins/quick-links@latest
```


## add new option
### buildAbsDir: use abs path
### reserveBuild: reserve the temp build dir