### PR TITLE
docs: fix Docker image tag in Quick Start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To learn more about the project, visit [answer.apache.org](https://answer.apache
 ### Running with docker
 
 ```bash
-docker run -d -p 9080:80 -v answer-data:/data --name answer apache/answer:2.0.0
+docker run -d -p 9080:80 -v answer-data:/data --name answer apache/answer:latest
 ```
 
 For more information, see [Installation](https://answer.apache.org/docs/installation).


### PR DESCRIPTION
Update Docker image from non-existent 2.0.0 to latest stable version. The exact tag apache/answer:2.0.0 does not exist on Docker Hub, only 2.0.0-RC2 (Release Candidate) exists. Quick Start should use stable releases for new users.

Fixes #1495