### PR TITLE
fix: change avatar column type to TEXT to support long URLs

### DIFF
--- a/internal/entity/user_entity.go
+++ b/internal/entity/user_entity.go
@@ -60,7 +60,7 @@ type User struct {
 	Status         int       `xorm:"not null default 1 INT(11) status"`
 	AuthorityGroup int       `xorm:"not null default 1 INT(11) authority_group"`
 	DisplayName    string    `xorm:"not null default '' VARCHAR(30) display_name"`
-	Avatar         string    `xorm:"not null default '' TEXT avatar"`
+	Avatar         string    `xorm:"not null TEXT avatar"`
 	Mobile         string    `xorm:"not null VARCHAR(20) mobile"`
 	Bio            string    `xorm:"not null TEXT bio"`
 	BioHTML        string    `xorm:"not null TEXT bio_html"`

--- a/internal/entity/user_entity.go
+++ b/internal/entity/user_entity.go
@@ -60,7 +60,7 @@ type User struct {
 	Status         int       `xorm:"not null default 1 INT(11) status"`
 	AuthorityGroup int       `xorm:"not null default 1 INT(11) authority_group"`
 	DisplayName    string    `xorm:"not null default '' VARCHAR(30) display_name"`
-	Avatar         string    `xorm:"not null default '' VARCHAR(2048) avatar"`
+	Avatar         string    `xorm:"not null default '' TEXT avatar"`
 	Mobile         string    `xorm:"not null VARCHAR(20) mobile"`
 	Bio            string    `xorm:"not null TEXT bio"`
 	BioHTML        string    `xorm:"not null TEXT bio_html"`

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -107,7 +107,7 @@ var migrations = []Migration{
 	NewMigration("v1.7.2", "expand avatar column length", expandAvatarColumnLength, false),
 	NewMigration("v1.8.0", "change admin menu", updateAdminMenuSettings, true),
 	NewMigration("v1.8.1", "ai feat", aiFeat, true),
-	NewMigration("v1.8.2", "change avatar type to text", updateAvatarType, false),
+	NewMigration("v2.0.1", "change avatar type to text", updateAvatarType, false),
 }
 
 func GetMigrations() []Migration {

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -107,6 +107,7 @@ var migrations = []Migration{
 	NewMigration("v1.7.2", "expand avatar column length", expandAvatarColumnLength, false),
 	NewMigration("v1.8.0", "change admin menu", updateAdminMenuSettings, true),
 	NewMigration("v1.8.1", "ai feat", aiFeat, true),
+	NewMigration("v1.8.2", "change avatar type to text", updateAvatarType, false),
 }
 
 func GetMigrations() []Migration {

--- a/internal/migrations/v32.go
+++ b/internal/migrations/v32.go
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/internal/migrations/v32.go
+++ b/internal/migrations/v32.go
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/answer/internal/entity"
+	"xorm.io/xorm"
+)
+
+func updateAvatarType(ctx context.Context, x *xorm.Engine) error {
+	// Sync the User struct to the database.
+	// Since you changed the struct to use TEXT, this will update the column type.
+	if err := x.Context(ctx).Sync(new(entity.User)); err != nil {
+		return fmt.Errorf("sync user table failed: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
### Type of change
- [x] Bug fix
#1498

### Description
This PR changes the `avatar` column type from `VARCHAR` to `TEXT` in the `user` table.

**Reason:**
Some Google profile image URLs exceed the previous character limit (1024/2048 chars), causing 500 errors during login or registration. Switching to `TEXT` ensures support for long URLs (up to 65kb).

### Changes
1. **Entity:** Updated `User` struct in `internal/entity/user_entity.go` to use `TEXT` for the avatar field.
2. **Migration:** Added `v1.8.2` migration (`internal/migrations/v32.go`) to alter the database column automatically.

### Verification
- Tested locally with MySQL.
- Verified that inserting a string longer than 2048 characters into the `avatar` column now succeeds without error.