### PR TITLE
fix: limit tall image height to improve screenshot viewing experience

### DIFF
--- a/ui/src/index.scss
+++ b/ui/src/index.scss
@@ -274,6 +274,9 @@ img[src=''] {
   }
   img {
     max-width: 100%;
+    max-height: 70vh;
+    height: auto;
+    object-fit: contain;
   }
   video {
     max-width: 100%;


### PR DESCRIPTION
small fix

Before
<img width="1454" height="964" alt="image" src="https://github.com/user-attachments/assets/57e65d05-40cb-4228-8255-3ec6ce2090c8" />

After
<img width="1452" height="954" alt="image" src="https://github.com/user-attachments/assets/9c1de655-c0f8-4c2f-be9e-9b03a2eb8f0e" />
