### PR TITLE
feat: add prompt configuration for AI settings

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -134,6 +134,77 @@
                 }
             }
         },
+        "/answer/admin/api/ai-prompt-config": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "get AI prompt configuration",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "get AI prompt configuration",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/handler.RespBody"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/schema.AIPromptConfig"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "update AI prompt configuration",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "update AI prompt configuration",
+                "parameters": [
+                    {
+                        "description": "AI prompt config",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/schema.AIPromptConfig"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.RespBody"
+                        }
+                    }
+                }
+            }
+        },
         "/answer/admin/api/ai-provider": {
             "get": {
                 "security": [

--- a/i18n/en_US.yaml
+++ b/i18n/en_US.yaml
@@ -2354,6 +2354,9 @@ ui:
       model:
         label: Model
         msg: Model is required
+      prompt:
+        label: Prompt
+        text: Shows the prompt for the current language. Edit and save to apply.
       add_success: AI settings updated successfully.
     conversations:
       topic: Topic
@@ -2482,5 +2485,4 @@ ui:
     copy: Copy to clipboard
     copied: Copied
     external_content_warning: External images/media are not displayed.
-
 

--- a/i18n/en_US.yaml
+++ b/i18n/en_US.yaml
@@ -2359,6 +2359,9 @@ ui:
         text: Shows the prompt for the current language. Edit and save to apply.
       add_success: AI settings updated successfully.
     conversations:
+      tabs:
+        conversations: Conversations
+        settings: Settings
       topic: Topic
       helpful: Helpful
       unhelpful: Unhelpful
@@ -2485,4 +2488,3 @@ ui:
     copy: Copy to clipboard
     copied: Copied
     external_content_warning: External images/media are not displayed.
-

--- a/i18n/zh_CN.yaml
+++ b/i18n/zh_CN.yaml
@@ -2323,6 +2323,9 @@ ui:
         text: 显示当前语言环境的提示词，可在此修改并保存。
       add_success: AI 设置更新成功。
     conversations:
+      tabs:
+        conversations: 对话
+        settings: 设置
       topic: 主题
       helpful: 有帮助
       unhelpful: 没有帮助
@@ -2449,5 +2452,3 @@ ui:
     copy: 复制到剪贴板
     copied: 已复制
     external_content_warning: 外部图像/媒体未显示。
-
-

--- a/i18n/zh_CN.yaml
+++ b/i18n/zh_CN.yaml
@@ -1796,7 +1796,7 @@ ui:
     security: 安全
     files: 文件
     apikeys: API 密钥
-    intelligence: 智力
+    intelligence: 智能
     ai_assistant: AI 助手
     ai_settings: AI 设置
     mcp: MCP
@@ -2318,6 +2318,9 @@ ui:
       model:
         label: 模型
         msg: 模型是必需的
+      prompt:
+        label: 提示词
+        text: 显示当前语言环境的提示词，可在此修改并保存。
       add_success: AI 设置更新成功。
     conversations:
       topic: 主题

--- a/internal/controller_admin/siteinfo_controller.go
+++ b/internal/controller_admin/siteinfo_controller.go
@@ -618,6 +618,38 @@ func (sc *SiteInfoController) UpdateAIConfig(ctx *gin.Context) {
 	handler.HandleResponse(ctx, err, nil)
 }
 
+// GetAIPromptConfig get AI prompt configuration
+// @Summary get AI prompt configuration
+// @Description get AI prompt configuration
+// @Security ApiKeyAuth
+// @Tags admin
+// @Produce json
+// @Success 200 {object} handler.RespBody{data=schema.AIPromptConfig}
+// @Router /answer/admin/api/ai-prompt-config [get]
+func (sc *SiteInfoController) GetAIPromptConfig(ctx *gin.Context) {
+	resp, err := sc.siteInfoService.GetAIPromptConfig(ctx)
+	handler.HandleResponse(ctx, err, resp)
+}
+
+// UpdateAIPromptConfig update AI prompt configuration
+// @Summary update AI prompt configuration
+// @Description update AI prompt configuration
+// @Security ApiKeyAuth
+// @Tags admin
+// @Param data body schema.AIPromptConfig true "AI prompt config"
+// @Produce json
+// @Success 200 {object} handler.RespBody{}
+// @Router /answer/admin/api/ai-prompt-config [put]
+func (sc *SiteInfoController) UpdateAIPromptConfig(ctx *gin.Context) {
+	req := &schema.AIPromptConfig{}
+	if handler.BindAndCheck(ctx, req) {
+		return
+	}
+
+	err := sc.siteInfoService.SaveAIPromptConfig(ctx, req)
+	handler.HandleResponse(ctx, err, nil)
+}
+
 // GetAIProvider get AI provider configuration
 // @Summary get AI provider configuration
 // @Description get AI provider configuration

--- a/internal/router/answer_api_router.go
+++ b/internal/router/answer_api_router.go
@@ -425,6 +425,8 @@ func (a *AnswerAPIRouter) RegisterAnswerAdminAPIRouter(r *gin.RouterGroup) {
 	// ai config
 	r.GET("/ai-config", a.adminSiteInfoController.GetAIConfig)
 	r.PUT("/ai-config", a.adminSiteInfoController.UpdateAIConfig)
+	r.GET("/ai-prompt-config", a.adminSiteInfoController.GetAIPromptConfig)
+	r.PUT("/ai-prompt-config", a.adminSiteInfoController.UpdateAIPromptConfig)
 	r.GET("/ai-provider", a.adminSiteInfoController.GetAIProvider)
 	r.POST("/ai-models", a.adminSiteInfoController.RequestAIModels)
 

--- a/internal/service/siteinfo/siteinfo_service.go
+++ b/internal/service/siteinfo/siteinfo_service.go
@@ -365,16 +365,52 @@ func (s *SiteInfoService) GetSiteAI(ctx context.Context) (resp *schema.SiteAIRes
 	return resp, nil
 }
 
+// GetAIPromptConfig get AI prompt configuration
+func (s *SiteInfoService) GetAIPromptConfig(ctx context.Context) (resp *schema.AIPromptConfig, err error) {
+	siteAI, err := s.siteInfoCommonService.GetSiteAI(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if siteAI.PromptConfig != nil {
+		return &schema.AIPromptConfig{
+			ZhCN: siteAI.PromptConfig.ZhCN,
+			EnUS: siteAI.PromptConfig.EnUS,
+		}, nil
+	}
+	return &schema.AIPromptConfig{
+		ZhCN: constant.DefaultAIPromptConfigZhCN,
+		EnUS: constant.DefaultAIPromptConfigEnUS,
+	}, nil
+}
+
+// SaveAIPromptConfig save AI prompt configuration
+func (s *SiteInfoService) SaveAIPromptConfig(ctx context.Context, req *schema.AIPromptConfig) (err error) {
+	siteAI, err := s.siteInfoCommonService.GetSiteAI(ctx)
+	if err != nil {
+		return err
+	}
+	siteAI.PromptConfig = req
+
+	content, _ := json.Marshal(siteAI)
+	siteInfo := &entity.SiteInfo{
+		Type:    constant.SiteTypeAI,
+		Content: string(content),
+		Status:  1,
+	}
+	return s.siteInfoRepo.SaveByType(ctx, constant.SiteTypeAI, siteInfo)
+}
+
 // SaveSiteAI save site AI configuration
 func (s *SiteInfoService) SaveSiteAI(ctx context.Context, req *schema.SiteAIReq) (err error) {
 	if err := s.restoreMaskedAIKeys(ctx, req); err != nil {
 		return err
 	}
 	if req.PromptConfig == nil {
-		req.PromptConfig = &schema.AIPromptConfig{
-			ZhCN: constant.DefaultAIPromptConfigZhCN,
-			EnUS: constant.DefaultAIPromptConfigEnUS,
+		promptConfig, err := s.GetAIPromptConfig(ctx)
+		if err != nil {
+			return err
 		}
+		req.PromptConfig = promptConfig
 	}
 
 	aiProvider, err := s.GetAIProvider(ctx)

--- a/ui/src/common/constants.ts
+++ b/ui/src/common/constants.ts
@@ -165,6 +165,11 @@ export const ADMIN_QA_NAV_MENUS = [
   { name: 'settings', path: '/admin/qa/settings' },
 ];
 
+export const ADMIN_AI_ASSISTANT_NAV_MENUS = [
+  { name: 'conversations', path: '/admin/ai-assistant' },
+  { name: 'settings', path: '/admin/ai-assistant/settings' },
+];
+
 export const ADMIN_TAGS_NAV_MENUS = [
   // { name: 'tags', path: '/admin/tags' },
   {

--- a/ui/src/common/interface.ts
+++ b/ui/src/common/interface.ts
@@ -834,6 +834,10 @@ export interface AiConfig {
     api_key: string;
     model: string;
   }>;
+  prompt_config?: {
+    zh_cn: string;
+    en_us: string;
+  };
 }
 
 export interface AiProviderItem {

--- a/ui/src/common/interface.ts
+++ b/ui/src/common/interface.ts
@@ -825,6 +825,11 @@ export interface AddOrEditApiKeyParams {
   id?: number;
 }
 
+export interface AIPromptConfig {
+  zh_cn: string;
+  en_us: string;
+}
+
 export interface AiConfig {
   enabled: boolean;
   chosen_provider: string;
@@ -834,10 +839,7 @@ export interface AiConfig {
     api_key: string;
     model: string;
   }>;
-  prompt_config?: {
-    zh_cn: string;
-    en_us: string;
-  };
+  prompt_config?: AIPromptConfig;
 }
 
 export interface AiProviderItem {

--- a/ui/src/components/TabNav/index.tsx
+++ b/ui/src/components/TabNav/index.tsx
@@ -22,8 +22,11 @@ import { Nav } from 'react-bootstrap';
 import { NavLink, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
-const TabNav: FC<{ menus: { name: string; path: string }[] }> = ({ menus }) => {
-  const { t } = useTranslation('translation', { keyPrefix: 'nav_menus' });
+const TabNav: FC<{
+  menus: { name: string; path: string }[];
+  i18nKeyPrefix?: string;
+}> = ({ menus, i18nKeyPrefix = 'nav_menus' }) => {
+  const { t } = useTranslation('translation', { keyPrefix: i18nKeyPrefix });
   const { pathname } = useLocation();
   return (
     <Nav variant="underline" className="mb-4 border-bottom">

--- a/ui/src/pages/Admin/AiAssistant/Settings/index.tsx
+++ b/ui/src/pages/Admin/AiAssistant/Settings/index.tsx
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { FormEvent, useEffect, useRef, useState } from 'react';
+import { Button, Form } from 'react-bootstrap';
+import { useTranslation } from 'react-i18next';
+
+import { TabNav } from '@/components';
+import { ADMIN_AI_ASSISTANT_NAV_MENUS } from '@/common/constants';
+import type * as Type from '@/common/interface';
+import { useToast } from '@/hooks';
+import { getAiPromptConfig, saveAiPromptConfig } from '@/services';
+
+const getPromptByLang = (
+  promptConfig: Type.AIPromptConfig | undefined,
+  lang: string,
+) => {
+  if (!promptConfig) {
+    return '';
+  }
+  const isZh = lang?.toLowerCase().startsWith('zh');
+  return isZh ? promptConfig.zh_cn || '' : promptConfig.en_us || '';
+};
+
+const Settings = () => {
+  const { t, i18n } = useTranslation('translation', {
+    keyPrefix: 'admin.conversations',
+  });
+  const toast = useToast();
+  const historyPromptConfigRef = useRef<Type.AIPromptConfig>();
+  const [isSaving, setIsSaving] = useState(false);
+  const [promptForm, setPromptForm] = useState({
+    value: '',
+    isInvalid: false,
+    errorMsg: '',
+  });
+  const isZhLang = i18n.language?.toLowerCase().startsWith('zh');
+
+  const getAiPromptConfigData = async () => {
+    const promptConfig = await getAiPromptConfig();
+    historyPromptConfigRef.current = promptConfig;
+    setPromptForm({
+      value: getPromptByLang(promptConfig, i18n.language),
+      isInvalid: false,
+      errorMsg: '',
+    });
+  };
+
+  const handleSavePrompt = (evt: FormEvent) => {
+    evt.preventDefault();
+    if (isSaving) {
+      return;
+    }
+    setIsSaving(true);
+    setPromptForm((prev) => ({
+      ...prev,
+      isInvalid: false,
+      errorMsg: '',
+    }));
+
+    const params: Type.AIPromptConfig = {
+      zh_cn: isZhLang
+        ? promptForm.value
+        : historyPromptConfigRef.current?.zh_cn || '',
+      en_us: isZhLang
+        ? historyPromptConfigRef.current?.en_us || ''
+        : promptForm.value,
+    };
+
+    saveAiPromptConfig(params)
+      .then(() => {
+        historyPromptConfigRef.current = params;
+        toast.onShow({
+          msg: t('update', { keyPrefix: 'toast' }),
+          variant: 'success',
+        });
+      })
+      .catch((err) => {
+        setPromptForm((prev) => ({
+          ...prev,
+          isInvalid: true,
+          errorMsg: err?.message || '',
+        }));
+      })
+      .finally(() => {
+        setIsSaving(false);
+      });
+  };
+
+  useEffect(() => {
+    getAiPromptConfigData();
+  }, []);
+
+  useEffect(() => {
+    if (!historyPromptConfigRef.current) {
+      return;
+    }
+    setPromptForm((prev) => ({
+      ...prev,
+      value: getPromptByLang(historyPromptConfigRef.current, i18n.language),
+      isInvalid: false,
+      errorMsg: '',
+    }));
+  }, [i18n.language]);
+
+  return (
+    <div className="d-flex flex-column flex-grow-1 position-relative">
+      <h3 className="mb-4">{t('ai_assistant', { keyPrefix: 'nav_menus' })}</h3>
+      <TabNav
+        menus={ADMIN_AI_ASSISTANT_NAV_MENUS}
+        i18nKeyPrefix="admin.conversations.tabs"
+      />
+
+      <div className="max-w-748">
+        <Form noValidate onSubmit={handleSavePrompt}>
+          <div className="mb-3">
+            <label className="form-label" htmlFor="admin-prompt-textarea">
+              {t('prompt.label', { keyPrefix: 'admin.ai_settings' })}
+            </label>
+            <Form.Control
+              id="admin-prompt-textarea"
+              as="textarea"
+              rows={10}
+              isInvalid={promptForm.isInvalid}
+              value={promptForm.value}
+              onChange={(e) =>
+                setPromptForm({
+                  value: e.target.value,
+                  isInvalid: false,
+                  errorMsg: '',
+                })
+              }
+            />
+            <div className="form-text mt-1">
+              {t('prompt.text', { keyPrefix: 'admin.ai_settings' })}
+            </div>
+            <Form.Control.Feedback type="invalid">
+              {promptForm.errorMsg}
+            </Form.Control.Feedback>
+          </div>
+          <Button type="submit" className="btn-primary" disabled={isSaving}>
+            {t('save', { keyPrefix: 'btns' })}
+          </Button>
+        </Form>
+      </div>
+    </div>
+  );
+};
+
+export default Settings;

--- a/ui/src/pages/Admin/AiAssistant/Settings/index.tsx
+++ b/ui/src/pages/Admin/AiAssistant/Settings/index.tsx
@@ -131,7 +131,9 @@ const Settings = () => {
         <Form noValidate onSubmit={handleSavePrompt}>
           <div className="mb-3">
             <label className="form-label" htmlFor="admin-prompt-textarea">
-              {t('prompt.label', { keyPrefix: 'admin.ai_settings' })}
+              <strong>
+                {t('prompt.label', { keyPrefix: 'admin.ai_settings' })}
+              </strong>
             </label>
             <Form.Control
               id="admin-prompt-textarea"

--- a/ui/src/pages/Admin/AiAssistant/index.tsx
+++ b/ui/src/pages/Admin/AiAssistant/index.tsx
@@ -17,24 +17,53 @@
  * under the License.
  */
 
-import { useState } from 'react';
-import { Table, Button } from 'react-bootstrap';
+import { FormEvent, useEffect, useRef, useState } from 'react';
+import { Table, Button, Nav, Form, Collapse } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 
 import { BaseUserCard, FormatTime, Pagination, Empty } from '@/components';
-import { useQueryAdminConversationList } from '@/services';
+import { useToast } from '@/hooks';
+import {
+  getAiConfig,
+  saveAiConfig,
+  useQueryAdminConversationList,
+} from '@/services';
+import * as Type from '@/common/interface';
 
 import DetailModal from './components/DetailModal';
 import Action from './components/Action';
 
+const getPromptByLang = (
+  promptConfig: Type.AiConfig['prompt_config'] | undefined,
+  lang: string,
+) => {
+  if (!promptConfig) {
+    return '';
+  }
+  const isZh = lang?.toLowerCase().startsWith('zh');
+  return isZh ? promptConfig.zh_cn || '' : promptConfig.en_us || '';
+};
+
 const Index = () => {
-  const { t } = useTranslation('translation', {
+  const { t, i18n } = useTranslation('translation', {
     keyPrefix: 'admin.conversations',
   });
+  const toast = useToast();
+  const historyConfigRef = useRef<Type.AiConfig>();
   const [urlSearchParams] = useSearchParams();
   const curPage = Number(urlSearchParams.get('page') || '1');
   const PAGE_SIZE = 20;
+  const [activeTab, setActiveTab] = useState<'conversations' | 'settings'>(
+    'conversations',
+  );
+  const [expandPrompt, setExpandPrompt] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [promptForm, setPromptForm] = useState({
+    value: '',
+    isInvalid: false,
+    errorMsg: '',
+  });
   const [detailModal, setDetailModal] = useState({
     visible: false,
     id: '',
@@ -47,6 +76,84 @@ const Index = () => {
     page: curPage,
     page_size: PAGE_SIZE,
   });
+  const isZhLang = i18n.language?.toLowerCase().startsWith('zh');
+
+  const getAiConfigData = async () => {
+    const aiConfig = await getAiConfig();
+    historyConfigRef.current = aiConfig;
+    setPromptForm({
+      value: getPromptByLang(aiConfig.prompt_config, i18n.language),
+      isInvalid: false,
+      errorMsg: '',
+    });
+  };
+
+  const handleSavePrompt = (evt: FormEvent) => {
+    evt.preventDefault();
+    if (!historyConfigRef.current || isSaving) {
+      return;
+    }
+    setIsSaving(true);
+    setPromptForm((prev) => ({
+      ...prev,
+      isInvalid: false,
+      errorMsg: '',
+    }));
+
+    const params: Type.AiConfig = {
+      enabled: historyConfigRef.current.enabled || false,
+      chosen_provider: historyConfigRef.current.chosen_provider || '',
+      ai_providers: historyConfigRef.current.ai_providers || [],
+      prompt_config: {
+        zh_cn: isZhLang
+          ? promptForm.value
+          : historyConfigRef.current.prompt_config?.zh_cn || '',
+        en_us: isZhLang
+          ? historyConfigRef.current.prompt_config?.en_us || ''
+          : promptForm.value,
+      },
+    };
+
+    saveAiConfig(params)
+      .then(() => {
+        historyConfigRef.current = params;
+        toast.onShow({
+          msg: t('update', { keyPrefix: 'toast' }),
+          variant: 'success',
+        });
+      })
+      .catch((err) => {
+        setPromptForm((prev) => ({
+          ...prev,
+          isInvalid: true,
+          errorMsg: err?.message || '',
+        }));
+      })
+      .finally(() => {
+        setIsSaving(false);
+      });
+  };
+
+  useEffect(() => {
+    if (activeTab === 'settings') {
+      getAiConfigData();
+    }
+  }, [activeTab]);
+
+  useEffect(() => {
+    if (!historyConfigRef.current || activeTab !== 'settings') {
+      return;
+    }
+    setPromptForm((prev) => ({
+      ...prev,
+      value: getPromptByLang(
+        historyConfigRef.current?.prompt_config,
+        i18n.language,
+      ),
+      isInvalid: false,
+      errorMsg: '',
+    }));
+  }, [i18n.language, activeTab]);
 
   const handleShowDetailModal = (data) => {
     setDetailModal({
@@ -65,60 +172,130 @@ const Index = () => {
   return (
     <div className="d-flex flex-column flex-grow-1 position-relative">
       <h3 className="mb-4">{t('ai_assistant', { keyPrefix: 'nav_menus' })}</h3>
-      <Table responsive="md">
-        <thead>
-          <tr>
-            <th className="min-w-15">{t('topic')}</th>
-            <th style={{ width: '10%' }}>{t('helpful')}</th>
-            <th style={{ width: '10%' }}>{t('unhelpful')}</th>
-            <th style={{ width: '20%' }}>{t('created')}</th>
-            <th style={{ width: '10%' }} className="text-end">
-              {t('action')}
-            </th>
-          </tr>
-        </thead>
-        <tbody className="align-middle">
-          {conversations?.list.map((item) => {
-            return (
-              <tr key={item.id}>
-                <td>
-                  <Button
-                    variant="link"
-                    className="p-0 text-decoration-none text-truncate max-w-30"
-                    onClick={() => handleShowDetailModal(item)}>
-                    {item.topic}
-                  </Button>
-                </td>
-                <td>{item.helpful_count}</td>
-                <td>{item.unhelpful_count}</td>
-                <td>
-                  <div className="vstack">
-                    <BaseUserCard data={item.user_info} avatarSize="20px" />
-                    <FormatTime
-                      className="small text-secondary"
-                      time={item.created_at}
-                    />
-                  </div>
-                </td>
-                <td className="text-end">
-                  <Action id={item.id} refreshList={refreshList} />
-                </td>
+      <Nav variant="underline" className="mb-4 border-bottom">
+        <Nav.Item>
+          <Nav.Link
+            className="px-0 me-4"
+            active={activeTab === 'conversations'}
+            onClick={() => setActiveTab('conversations')}>
+            {t('tabs.conversations')}
+          </Nav.Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Nav.Link
+            className="px-0"
+            active={activeTab === 'settings'}
+            onClick={() => setActiveTab('settings')}>
+            {t('tabs.settings')}
+          </Nav.Link>
+        </Nav.Item>
+      </Nav>
+
+      {activeTab === 'conversations' && (
+        <>
+          <Table responsive="md">
+            <thead>
+              <tr>
+                <th className="min-w-15">{t('topic')}</th>
+                <th style={{ width: '10%' }}>{t('helpful')}</th>
+                <th style={{ width: '10%' }}>{t('unhelpful')}</th>
+                <th style={{ width: '20%' }}>{t('created')}</th>
+                <th style={{ width: '10%' }} className="text-end">
+                  {t('action')}
+                </th>
               </tr>
-            );
-          })}
-        </tbody>
-      </Table>
-      {!isLoading && Number(conversations?.count) <= 0 && (
-        <Empty>{t('empty')}</Empty>
+            </thead>
+            <tbody className="align-middle">
+              {conversations?.list.map((item) => {
+                return (
+                  <tr key={item.id}>
+                    <td>
+                      <Button
+                        variant="link"
+                        className="p-0 text-decoration-none text-truncate max-w-30"
+                        onClick={() => handleShowDetailModal(item)}>
+                        {item.topic}
+                      </Button>
+                    </td>
+                    <td>{item.helpful_count}</td>
+                    <td>{item.unhelpful_count}</td>
+                    <td>
+                      <div className="vstack">
+                        <BaseUserCard data={item.user_info} avatarSize="20px" />
+                        <FormatTime
+                          className="small text-secondary"
+                          time={item.created_at}
+                        />
+                      </div>
+                    </td>
+                    <td className="text-end">
+                      <Action id={item.id} refreshList={refreshList} />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </Table>
+          {!isLoading && Number(conversations?.count) <= 0 && (
+            <Empty>{t('empty')}</Empty>
+          )}
+          <div className="mt-4 mb-2 d-flex justify-content-center">
+            <Pagination
+              currentPage={curPage}
+              totalSize={conversations?.count || 0}
+              pageSize={PAGE_SIZE}
+            />
+          </div>
+        </>
       )}
 
-      <div className="mt-4 mb-2 d-flex justify-content-center">
-        <Pagination
-          currentPage={curPage}
-          totalSize={conversations?.count || 0}
-          pageSize={PAGE_SIZE}
-        />
-      </div>
+      {activeTab === 'settings' && (
+        <div className="max-w-748">
+          <div className="border rounded">
+            <button
+              type="button"
+              className={`btn btn-link w-100 text-start d-flex justify-content-between align-items-center px-3 py-3 text-decoration-none ${
+                expandPrompt ? 'expanding' : ''
+              }`}
+              onClick={() => setExpandPrompt((prev) => !prev)}>
+              <span className="fw-medium">
+                {t('prompt.label', { keyPrefix: 'admin.ai_settings' })}
+              </span>
+              <i className="br bi-chevron-right collapse-indicator" />
+            </button>
+            <Collapse in={expandPrompt}>
+              <div className="px-3 pb-3 border-top">
+                <Form onSubmit={handleSavePrompt}>
+                  <div className="text-muted mt-3 mb-2">
+                    {t('prompt.text', { keyPrefix: 'admin.ai_settings' })}
+                  </div>
+                  <Form.Group controlId="prompt">
+                    <Form.Control
+                      as="textarea"
+                      rows={8}
+                      isInvalid={promptForm.isInvalid}
+                      value={promptForm.value}
+                      onChange={(e) =>
+                        setPromptForm({
+                          value: e.target.value,
+                          isInvalid: false,
+                          errorMsg: '',
+                        })
+                      }
+                    />
+                    <Form.Control.Feedback type="invalid">
+                      {promptForm.errorMsg}
+                    </Form.Control.Feedback>
+                  </Form.Group>
+                  <Button type="submit" className="mt-3" disabled={isSaving}>
+                    {t('save', { keyPrefix: 'btns' })}
+                  </Button>
+                </Form>
+              </div>
+            </Collapse>
+          </div>
+        </div>
+      )}
       <DetailModal
         visible={detailModal.visible}
         id={detailModal.id}

--- a/ui/src/pages/Admin/AiAssistant/index.tsx
+++ b/ui/src/pages/Admin/AiAssistant/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { FormEvent, useEffect, useRef, useState } from 'react';
-import { Table, Button, Nav, Form, Collapse } from 'react-bootstrap';
+import { Table, Button, Nav, Form } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 
@@ -57,7 +57,6 @@ const Index = () => {
   const [activeTab, setActiveTab] = useState<'conversations' | 'settings'>(
     'conversations',
   );
-  const [expandPrompt, setExpandPrompt] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [promptForm, setPromptForm] = useState({
     value: '',
@@ -251,49 +250,36 @@ const Index = () => {
 
       {activeTab === 'settings' && (
         <div className="max-w-748">
-          <div className="border rounded">
-            <button
-              type="button"
-              className={`btn btn-link w-100 text-start d-flex justify-content-between align-items-center px-3 py-3 text-decoration-none ${
-                expandPrompt ? 'expanding' : ''
-              }`}
-              onClick={() => setExpandPrompt((prev) => !prev)}>
-              <span className="fw-medium">
+          <Form noValidate onSubmit={handleSavePrompt}>
+            <div className="mb-3">
+              <label className="form-label" htmlFor="admin-prompt-textarea">
                 {t('prompt.label', { keyPrefix: 'admin.ai_settings' })}
-              </span>
-              <i className="br bi-chevron-right collapse-indicator" />
-            </button>
-            <Collapse in={expandPrompt}>
-              <div className="px-3 pb-3 border-top">
-                <Form onSubmit={handleSavePrompt}>
-                  <div className="text-muted mt-3 mb-2">
-                    {t('prompt.text', { keyPrefix: 'admin.ai_settings' })}
-                  </div>
-                  <Form.Group controlId="prompt">
-                    <Form.Control
-                      as="textarea"
-                      rows={8}
-                      isInvalid={promptForm.isInvalid}
-                      value={promptForm.value}
-                      onChange={(e) =>
-                        setPromptForm({
-                          value: e.target.value,
-                          isInvalid: false,
-                          errorMsg: '',
-                        })
-                      }
-                    />
-                    <Form.Control.Feedback type="invalid">
-                      {promptForm.errorMsg}
-                    </Form.Control.Feedback>
-                  </Form.Group>
-                  <Button type="submit" className="mt-3" disabled={isSaving}>
-                    {t('save', { keyPrefix: 'btns' })}
-                  </Button>
-                </Form>
+              </label>
+              <Form.Control
+                id="admin-prompt-textarea"
+                as="textarea"
+                rows={10}
+                isInvalid={promptForm.isInvalid}
+                value={promptForm.value}
+                onChange={(e) =>
+                  setPromptForm({
+                    value: e.target.value,
+                    isInvalid: false,
+                    errorMsg: '',
+                  })
+                }
+              />
+              <div className="form-text mt-1">
+                {t('prompt.text', { keyPrefix: 'admin.ai_settings' })}
               </div>
-            </Collapse>
-          </div>
+              <Form.Control.Feedback type="invalid">
+                {promptForm.errorMsg}
+              </Form.Control.Feedback>
+            </div>
+            <Button type="submit" className="btn-primary" disabled={isSaving}>
+              {t('save', { keyPrefix: 'btns' })}
+            </Button>
+          </Form>
         </div>
       )}
       <DetailModal

--- a/ui/src/pages/Admin/AiAssistant/index.tsx
+++ b/ui/src/pages/Admin/AiAssistant/index.tsx
@@ -17,52 +17,31 @@
  * under the License.
  */
 
-import { FormEvent, useEffect, useRef, useState } from 'react';
-import { Table, Button, Nav, Form } from 'react-bootstrap';
+import { useState } from 'react';
+import { Table, Button } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 
-import { BaseUserCard, FormatTime, Pagination, Empty } from '@/components';
-import { useToast } from '@/hooks';
 import {
-  getAiConfig,
-  saveAiConfig,
-  useQueryAdminConversationList,
-} from '@/services';
-import * as Type from '@/common/interface';
+  BaseUserCard,
+  FormatTime,
+  Pagination,
+  Empty,
+  TabNav,
+} from '@/components';
+import { ADMIN_AI_ASSISTANT_NAV_MENUS } from '@/common/constants';
+import { useQueryAdminConversationList } from '@/services';
 
 import DetailModal from './components/DetailModal';
 import Action from './components/Action';
 
-const getPromptByLang = (
-  promptConfig: Type.AiConfig['prompt_config'] | undefined,
-  lang: string,
-) => {
-  if (!promptConfig) {
-    return '';
-  }
-  const isZh = lang?.toLowerCase().startsWith('zh');
-  return isZh ? promptConfig.zh_cn || '' : promptConfig.en_us || '';
-};
-
 const Index = () => {
-  const { t, i18n } = useTranslation('translation', {
+  const { t } = useTranslation('translation', {
     keyPrefix: 'admin.conversations',
   });
-  const toast = useToast();
-  const historyConfigRef = useRef<Type.AiConfig>();
   const [urlSearchParams] = useSearchParams();
   const curPage = Number(urlSearchParams.get('page') || '1');
   const PAGE_SIZE = 20;
-  const [activeTab, setActiveTab] = useState<'conversations' | 'settings'>(
-    'conversations',
-  );
-  const [isSaving, setIsSaving] = useState(false);
-  const [promptForm, setPromptForm] = useState({
-    value: '',
-    isInvalid: false,
-    errorMsg: '',
-  });
   const [detailModal, setDetailModal] = useState({
     visible: false,
     id: '',
@@ -75,84 +54,6 @@ const Index = () => {
     page: curPage,
     page_size: PAGE_SIZE,
   });
-  const isZhLang = i18n.language?.toLowerCase().startsWith('zh');
-
-  const getAiConfigData = async () => {
-    const aiConfig = await getAiConfig();
-    historyConfigRef.current = aiConfig;
-    setPromptForm({
-      value: getPromptByLang(aiConfig.prompt_config, i18n.language),
-      isInvalid: false,
-      errorMsg: '',
-    });
-  };
-
-  const handleSavePrompt = (evt: FormEvent) => {
-    evt.preventDefault();
-    if (!historyConfigRef.current || isSaving) {
-      return;
-    }
-    setIsSaving(true);
-    setPromptForm((prev) => ({
-      ...prev,
-      isInvalid: false,
-      errorMsg: '',
-    }));
-
-    const params: Type.AiConfig = {
-      enabled: historyConfigRef.current.enabled || false,
-      chosen_provider: historyConfigRef.current.chosen_provider || '',
-      ai_providers: historyConfigRef.current.ai_providers || [],
-      prompt_config: {
-        zh_cn: isZhLang
-          ? promptForm.value
-          : historyConfigRef.current.prompt_config?.zh_cn || '',
-        en_us: isZhLang
-          ? historyConfigRef.current.prompt_config?.en_us || ''
-          : promptForm.value,
-      },
-    };
-
-    saveAiConfig(params)
-      .then(() => {
-        historyConfigRef.current = params;
-        toast.onShow({
-          msg: t('update', { keyPrefix: 'toast' }),
-          variant: 'success',
-        });
-      })
-      .catch((err) => {
-        setPromptForm((prev) => ({
-          ...prev,
-          isInvalid: true,
-          errorMsg: err?.message || '',
-        }));
-      })
-      .finally(() => {
-        setIsSaving(false);
-      });
-  };
-
-  useEffect(() => {
-    if (activeTab === 'settings') {
-      getAiConfigData();
-    }
-  }, [activeTab]);
-
-  useEffect(() => {
-    if (!historyConfigRef.current || activeTab !== 'settings') {
-      return;
-    }
-    setPromptForm((prev) => ({
-      ...prev,
-      value: getPromptByLang(
-        historyConfigRef.current?.prompt_config,
-        i18n.language,
-      ),
-      isInvalid: false,
-      errorMsg: '',
-    }));
-  }, [i18n.language, activeTab]);
 
   const handleShowDetailModal = (data) => {
     setDetailModal({
@@ -171,117 +72,65 @@ const Index = () => {
   return (
     <div className="d-flex flex-column flex-grow-1 position-relative">
       <h3 className="mb-4">{t('ai_assistant', { keyPrefix: 'nav_menus' })}</h3>
-      <Nav variant="underline" className="mb-4 border-bottom">
-        <Nav.Item>
-          <Nav.Link
-            className="px-0 me-4"
-            active={activeTab === 'conversations'}
-            onClick={() => setActiveTab('conversations')}>
-            {t('tabs.conversations')}
-          </Nav.Link>
-        </Nav.Item>
-        <Nav.Item>
-          <Nav.Link
-            className="px-0"
-            active={activeTab === 'settings'}
-            onClick={() => setActiveTab('settings')}>
-            {t('tabs.settings')}
-          </Nav.Link>
-        </Nav.Item>
-      </Nav>
+      <TabNav
+        menus={ADMIN_AI_ASSISTANT_NAV_MENUS}
+        i18nKeyPrefix="admin.conversations.tabs"
+      />
 
-      {activeTab === 'conversations' && (
-        <>
-          <Table responsive="md">
-            <thead>
-              <tr>
-                <th className="min-w-15">{t('topic')}</th>
-                <th style={{ width: '10%' }}>{t('helpful')}</th>
-                <th style={{ width: '10%' }}>{t('unhelpful')}</th>
-                <th style={{ width: '20%' }}>{t('created')}</th>
-                <th style={{ width: '10%' }} className="text-end">
-                  {t('action')}
-                </th>
+      <Table responsive="md">
+        <thead>
+          <tr>
+            <th className="min-w-15">{t('topic')}</th>
+            <th style={{ width: '10%' }}>{t('helpful')}</th>
+            <th style={{ width: '10%' }}>{t('unhelpful')}</th>
+            <th style={{ width: '20%' }}>{t('created')}</th>
+            <th style={{ width: '10%' }} className="text-end">
+              {t('action')}
+            </th>
+          </tr>
+        </thead>
+        <tbody className="align-middle">
+          {conversations?.list.map((item) => {
+            return (
+              <tr key={item.id}>
+                <td>
+                  <Button
+                    variant="link"
+                    className="p-0 text-decoration-none text-truncate max-w-30"
+                    onClick={() => handleShowDetailModal(item)}>
+                    {item.topic}
+                  </Button>
+                </td>
+                <td>{item.helpful_count}</td>
+                <td>{item.unhelpful_count}</td>
+                <td>
+                  <div className="vstack">
+                    <BaseUserCard data={item.user_info} avatarSize="20px" />
+                    <FormatTime
+                      className="small text-secondary"
+                      time={item.created_at}
+                    />
+                  </div>
+                </td>
+                <td className="text-end">
+                  <Action id={item.id} refreshList={refreshList} />
+                </td>
               </tr>
-            </thead>
-            <tbody className="align-middle">
-              {conversations?.list.map((item) => {
-                return (
-                  <tr key={item.id}>
-                    <td>
-                      <Button
-                        variant="link"
-                        className="p-0 text-decoration-none text-truncate max-w-30"
-                        onClick={() => handleShowDetailModal(item)}>
-                        {item.topic}
-                      </Button>
-                    </td>
-                    <td>{item.helpful_count}</td>
-                    <td>{item.unhelpful_count}</td>
-                    <td>
-                      <div className="vstack">
-                        <BaseUserCard data={item.user_info} avatarSize="20px" />
-                        <FormatTime
-                          className="small text-secondary"
-                          time={item.created_at}
-                        />
-                      </div>
-                    </td>
-                    <td className="text-end">
-                      <Action id={item.id} refreshList={refreshList} />
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </Table>
-          {!isLoading && Number(conversations?.count) <= 0 && (
-            <Empty>{t('empty')}</Empty>
-          )}
-          <div className="mt-4 mb-2 d-flex justify-content-center">
-            <Pagination
-              currentPage={curPage}
-              totalSize={conversations?.count || 0}
-              pageSize={PAGE_SIZE}
-            />
-          </div>
-        </>
+            );
+          })}
+        </tbody>
+      </Table>
+      {!isLoading && Number(conversations?.count) <= 0 && (
+        <Empty>{t('empty')}</Empty>
       )}
+      <div className="mt-4 mb-2 d-flex justify-content-center">
+        <Pagination
+          currentPage={curPage}
+          totalSize={conversations?.count || 0}
+          pageSize={PAGE_SIZE}
+        />
+      </div>
 
-      {activeTab === 'settings' && (
-        <div className="max-w-748">
-          <Form noValidate onSubmit={handleSavePrompt}>
-            <div className="mb-3">
-              <label className="form-label" htmlFor="admin-prompt-textarea">
-                {t('prompt.label', { keyPrefix: 'admin.ai_settings' })}
-              </label>
-              <Form.Control
-                id="admin-prompt-textarea"
-                as="textarea"
-                rows={10}
-                isInvalid={promptForm.isInvalid}
-                value={promptForm.value}
-                onChange={(e) =>
-                  setPromptForm({
-                    value: e.target.value,
-                    isInvalid: false,
-                    errorMsg: '',
-                  })
-                }
-              />
-              <div className="form-text mt-1">
-                {t('prompt.text', { keyPrefix: 'admin.ai_settings' })}
-              </div>
-              <Form.Control.Feedback type="invalid">
-                {promptForm.errorMsg}
-              </Form.Control.Feedback>
-            </div>
-            <Button type="submit" className="btn-primary" disabled={isSaving}>
-              {t('save', { keyPrefix: 'btns' })}
-            </Button>
-          </Form>
-        </div>
-      )}
       <DetailModal
         visible={detailModal.visible}
         id={detailModal.id}

--- a/ui/src/pages/Admin/AiSettings/index.tsx
+++ b/ui/src/pages/Admin/AiSettings/index.tsx
@@ -32,19 +32,8 @@ import { handleFormError } from '@/utils';
 import { useToast } from '@/hooks';
 import * as Type from '@/common/interface';
 
-const getPromptByLang = (
-  promptConfig: Type.AiConfig['prompt_config'] | undefined,
-  lang: string,
-) => {
-  if (!promptConfig) {
-    return '';
-  }
-  const isZh = lang?.toLowerCase().startsWith('zh');
-  return isZh ? promptConfig.zh_cn || '' : promptConfig.en_us || '';
-};
-
 const Index = () => {
-  const { t, i18n } = useTranslation('translation', {
+  const { t } = useTranslation('translation', {
     keyPrefix: 'admin.ai_settings',
   });
   const toast = useToast();
@@ -79,17 +68,10 @@ const Index = () => {
       isInvalid: false,
       errorMsg: '',
     },
-    prompt: {
-      value: '',
-      isInvalid: false,
-      errorMsg: '',
-    },
   });
   const [apiHostPlaceholder, setApiHostPlaceholder] = useState('');
   const [modelsData, setModels] = useState<{ id: string }[]>([]);
   const [isChecking, setIsChecking] = useState(false);
-
-  const isZhLang = i18n.language?.toLowerCase().startsWith('zh');
 
   const getCurrentProviderData = (provider) => {
     const findHistoryProvider =
@@ -246,12 +228,8 @@ const Index = () => {
       chosen_provider: formData.provider.value,
       ai_providers: newProviders,
       prompt_config: {
-        zh_cn: isZhLang
-          ? formData.prompt.value
-          : historyConfigRef.current?.prompt_config?.zh_cn || '',
-        en_us: isZhLang
-          ? historyConfigRef.current?.prompt_config?.en_us || ''
-          : formData.prompt.value,
+        zh_cn: historyConfigRef.current?.prompt_config?.zh_cn || '',
+        en_us: historyConfigRef.current?.prompt_config?.en_us || '',
       },
     };
     saveAiConfig(params)
@@ -321,11 +299,6 @@ const Index = () => {
         isInvalid: false,
         errorMsg: '',
       },
-      prompt: {
-        value: getPromptByLang(aiConfig.prompt_config, i18n.language),
-        isInvalid: false,
-        errorMsg: '',
-      },
     });
   };
 
@@ -353,22 +326,6 @@ const Index = () => {
     }
   }, [aiProviders, formData]);
 
-  useEffect(() => {
-    if (!historyConfigRef.current) {
-      return;
-    }
-    setFormData((prev) => ({
-      ...prev,
-      prompt: {
-        value: getPromptByLang(
-          historyConfigRef.current?.prompt_config,
-          i18n.language,
-        ),
-        isInvalid: false,
-        errorMsg: '',
-      },
-    }));
-  }, [i18n.language]);
   return (
     <div>
       <h3 className="mb-4">{t('ai_settings', { keyPrefix: 'nav_menus' })}</h3>
@@ -523,29 +480,6 @@ const Index = () => {
 
             <div className="invalid-feedback">{formData.model.errorMsg}</div>
           </div>
-
-          <Form.Group className="mb-3" controlId="prompt">
-            <Form.Label>{t('prompt.label')}</Form.Label>
-            <Form.Control
-              as="textarea"
-              rows={8}
-              isInvalid={formData.prompt.isInvalid}
-              value={formData.prompt.value}
-              onChange={(e) =>
-                handleValueChange({
-                  prompt: {
-                    value: e.target.value,
-                    errorMsg: '',
-                    isInvalid: false,
-                  },
-                })
-              }
-            />
-            <Form.Text className="text-muted">{t('prompt.text')}</Form.Text>
-            <Form.Control.Feedback type="invalid">
-              {formData.prompt.errorMsg}
-            </Form.Control.Feedback>
-          </Form.Group>
 
           <Button type="submit">{t('save', { keyPrefix: 'btns' })}</Button>
         </Form>

--- a/ui/src/pages/Admin/AiSettings/index.tsx
+++ b/ui/src/pages/Admin/AiSettings/index.tsx
@@ -227,10 +227,6 @@ const Index = () => {
       enabled: formData.enabled.value,
       chosen_provider: formData.provider.value,
       ai_providers: newProviders,
-      prompt_config: {
-        zh_cn: historyConfigRef.current?.prompt_config?.zh_cn || '',
-        en_us: historyConfigRef.current?.prompt_config?.en_us || '',
-      },
     };
     saveAiConfig(params)
       .then(() => {

--- a/ui/src/router/routes.ts
+++ b/ui/src/router/routes.ts
@@ -450,6 +450,10 @@ const routes: RouteNode[] = [
             page: 'pages/Admin/AiAssistant',
           },
           {
+            path: 'ai-assistant/settings',
+            page: 'pages/Admin/AiAssistant/Settings',
+          },
+          {
             path: 'ai-settings',
             page: 'pages/Admin/AiSettings',
           },

--- a/ui/src/services/admin/ai.ts
+++ b/ui/src/services/admin/ai.ts
@@ -49,6 +49,14 @@ export const saveAiConfig = (params) => {
   return request.put('/answer/admin/api/ai-config', params);
 };
 
+export const getAiPromptConfig = () => {
+  return request.get<Type.AIPromptConfig>('/answer/admin/api/ai-prompt-config');
+};
+
+export const saveAiPromptConfig = (params: Type.AIPromptConfig) => {
+  return request.put('/answer/admin/api/ai-prompt-config', params);
+};
+
 export const useQueryAdminConversationDetail = (id: string) => {
   const apiUrl = !id
     ? null


### PR DESCRIPTION
I added prompt configuration in AI settings

now admin can edit prompt in "Admin" > "Intelligence" > "AI Settings".

This will display the prompt corresponding to each language in different languages, but currently I have only implemented Chinese and English.


https://github.com/user-attachments/assets/1219cba5-b247-43df-9cff-7f021e59ceb7



### English
<img width="1185" height="500" alt="image" src="https://github.com/user-attachments/assets/d0069b9c-07a3-41ab-b1d7-9640ded45d5a" />

### Chinese
<img width="1104" height="470" alt="image" src="https://github.com/user-attachments/assets/03b67638-5041-4e2e-b723-33b6e8e440dc" />

By the way, I also changed the Chinese translation of “intelligence” from “智力” to “智能,” because “智力” is more like the noun “IQ” or “smartness,” used for humans or animals.

