### PR TITLE
fix: update bubble user background color for dark mode

### DIFF
--- a/ui/src/components/BubbleUser/index.scss
+++ b/ui/src/components/BubbleUser/index.scss
@@ -21,5 +21,9 @@
   scroll-margin-top: 88px;
 }
 .bubble-user {
-  background-color: var(--bs-gray-800);
+  background-color: var(--bs-gray-200);
+
+  [data-bs-theme='dark'] & {
+    background-color: var(--bs-gray-800);
+  }
 }

--- a/ui/src/components/BubbleUser/index.scss
+++ b/ui/src/components/BubbleUser/index.scss
@@ -21,5 +21,5 @@
   scroll-margin-top: 88px;
 }
 .bubble-user {
-  background-color: var(--bs-gray-200);
+  background-color: var(--bs-gray-800);
 }


### PR DESCRIPTION
### Before

<img width="1061" height="627" alt="image" src="https://github.com/user-attachments/assets/ee4462cf-cea3-4447-aa85-0393e6a506d1" />

### After

<img width="1069" height="627" alt="image" src="https://github.com/user-attachments/assets/7db5a140-2823-460f-b70d-bd7beed8dea4" />
