### PR TITLE
fix: resolve local plugin paths to absolute and enhance module replacement logic

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -140,6 +140,12 @@ func formatPlugins(plugins []string) (formatted []*pluginInfo) {
 		info := &pluginInfo{}
 		plugin, info.Path, _ = strings.Cut(plugin, "=")
 		info.Name, info.Version, _ = strings.Cut(plugin, "@")
+		// Resolve local path to absolute since build runs in a temp directory
+		if len(info.Path) > 0 {
+			if absPath, err := filepath.Abs(info.Path); err == nil {
+				info.Path = absPath
+			}
+		}
 		formatted = append(formatted, info)
 	}
 	return formatted
@@ -185,7 +191,12 @@ func createMainGoFile(b *buildingMaterial) (err error) {
 	for _, p := range b.plugins {
 		// If user set a path, use it to replace the module with local path
 		if len(p.Path) > 0 {
-			replacement := fmt.Sprintf("%s@%s=%s", p.Name, p.Version, p.Path)
+			var replacement string
+			if len(p.Version) > 0 {
+				replacement = fmt.Sprintf("%s@%s=%s", p.Name, p.Version, p.Path)
+			} else {
+				replacement = fmt.Sprintf("%s=%s", p.Name, p.Path)
+			}
 			err = b.newExecCmd("go", "mod", "edit", "-replace", replacement).Run()
 		} else if len(p.Version) > 0 {
 			// If user specify a version, use it to get specific version of the module
@@ -413,6 +424,13 @@ func copyDirEntries(sourceFs fs.FS, sourceDir, targetDir string, ignoreDir ...st
 	ignoreThisDir := func(path string) bool {
 		for _, s := range ignoreDir {
 			if strings.HasPrefix(path, s) {
+				return true
+			}
+			// Also ignore nested occurrences, e.g. src/plugins/foo/node_modules
+			if strings.Contains(path, string(filepath.Separator)+s) {
+				return true
+			}
+			if strings.Contains(path, "/"+s) {
 				return true
 			}
 		}


### PR DESCRIPTION
Fix #1519 .

works with below cmd.

```
build-local-vector-plugins:
	@cd new_answer/answer_with_plugin && \
	CGO_ENABLED=0 go build -o answer ./... && \
	ANSWER_MODULE=$$(pwd)/../../ ./answer build \
	  --with "github.com/apache/answer-plugins/vector-search-pgvector=$$(pwd)/../../../answer-plugins/vector-search-pgvector" \
	  --with "github.com/apache/answer-plugins/vector-search-elasticsearch=$$(pwd)/../../../answer-plugins/vector-search-elasticsearch" \
	  --with "github.com/apache/answer-plugins/vector-search-weaviate=$$(pwd)/../../../answer-plugins/vector-search-weaviate" \
	  --with "github.com/apache/answer-plugins/vector-search-milvus=$$(pwd)/../../../answer-plugins/vector-search-milvus" \
	  --with "github.com/apache/answer-plugins/vector-search-qdrant=$$(pwd)/../../../answer-plugins/vector-search-qdrant" \
	  --with "github.com/apache/answer-plugins/vector-search-chromadb=$$(pwd)/../../../answer-plugins/vector-search-chromadb" \
	  --with "github.com/apache/answer-plugins/vector-search-memory=$$(pwd)/../../../answer-plugins/vector-search-memory" \
	  --output ./new_answer_with_plugins
```

<img width="645" height="262" alt="image" src="https://github.com/user-attachments/assets/e37a647e-c0a0-4fc0-ad17-11d6fc460317" />

