### PR TITLE
fix: support API key authentication in private mode

### DIFF
--- a/internal/base/middleware/auth.go
+++ b/internal/base/middleware/auth.go
@@ -92,6 +92,15 @@ func (am *AuthUserMiddleware) EjectUserBySiteInfo() gin.HandlerFunc {
 		// If site in private mode, user must login.
 		userInfo := GetUserInfoFromContext(ctx)
 		if userInfo == nil {
+			// Also check for valid API key authentication.
+			token := ExtractToken(ctx)
+			if len(token) > 0 {
+				pass, _ := am.authService.AuthAPIKey(ctx, ctx.Request.Method == "GET", token)
+				if pass {
+					ctx.Next()
+					return
+				}
+			}
 			handler.HandleResponse(ctx, errors.Unauthorized(reason.UnauthorizedError), nil)
 			ctx.Abort()
 			return


### PR DESCRIPTION
## Summary

Closes #1508

When `LoginRequired=true` (private mode), the `EjectUserBySiteInfo` middleware only checked for session-based authentication (cookies). Requests with valid API keys in the `Authorization` header were rejected with 401 Unauthorized.

## Change

**File:** `internal/base/middleware/auth.go` — `EjectUserBySiteInfo()`

When no user session is found in the context, the middleware now falls back to API key validation via `authService.AuthAPIKey()` before rejecting the request. This reuses the same validation logic already used by the `AuthAPIKey()` middleware for MCP routes.

```go
// Before: immediately reject if no user session
if userInfo == nil {
    // 401 Unauthorized
}

// After: try API key before rejecting
if userInfo == nil {
    token := ExtractToken(ctx)
    if len(token) > 0 {
        pass, _ := am.authService.AuthAPIKey(ctx, ctx.Request.Method == "GET", token)
        if pass {
            ctx.Next()
            return
        }
    }
    // 401 Unauthorized
}
```

## Test plan

- [x] `go build ./...` compiles successfully
- [x] Read-only API key + GET request in private mode → allowed
- [x] Write-scope API key + POST request in private mode → allowed
- [x] Read-only API key + POST request in private mode → rejected (scope check)
- [x] No token in private mode → rejected (existing behavior unchanged)
- [x] Session-based auth in private mode → works as before
- [x] Public mode (LoginRequired=false) → no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)