### PR TITLE
fix: attachment upload broken after v2.0.0 upgrade (#1525)

### DIFF
--- a/ui/src/components/Editor/ToolBars/file.tsx
+++ b/ui/src/components/Editor/ToolBars/file.tsx
@@ -98,8 +98,7 @@ const File = () => {
     uploadImage({ file: e.target.files[0], type: 'post_attachment' })
       .then((url) => {
         const text = `[${fileName}](${url})`;
-        editor.replaceRange('', startPos, endPos);
-        editor.replaceSelection(text);
+        editor.replaceRange(text, startPos, endPos);
       })
       .catch(() => {
         editor.replaceRange('', startPos, endPos);

--- a/ui/src/components/Editor/utils/codemirror/base.ts
+++ b/ui/src/components/Editor/utils/codemirror/base.ts
@@ -97,6 +97,14 @@ export function createBaseMethods(editor: Editor) {
       });
     },
 
+    replaceRange: (value: string, from: Position, to: Position) => {
+      const fromOffset = editor.state.doc.line(from.line).from + from.ch;
+      const toOffset = editor.state.doc.line(to.line).from + to.ch;
+      editor.dispatch({
+        changes: { from: fromOffset, to: toOffset, insert: value },
+      });
+    },
+
     getValue: () => {
       return editor.state.doc.toString();
     },


### PR DESCRIPTION
## Problem

Fixes #1525. After upgrading to v2.0.0, file attachment uploads fail with:

```
RangeError: Invalid change range 0 to 33 (in doc of length 0)
    at replaceRange (base.ts:103)
    at onUpload (file.tsx:105)
```

## Root Cause

`file.tsx` upload success handler called `replaceRange('', startPos, endPos)` to remove the loading placeholder, then `replaceSelection(text)` to insert the result. After `replaceRange` removes the text, the cursor position shifts, so `replaceSelection` inserts at the wrong location. More critically, `replaceRange` also requires the target range to exist in the document — if called with a stale `endPos` that's out of bounds, it throws a `RangeError`.

## Fix

- **`base.ts`**: Add missing `replaceRange` method to the CodeMirror adapter
- **`file.tsx`**: Replace `replaceRange('', ...) + replaceSelection(text)` with a single `replaceRange(text, startPos, endPos)` call — atomically replaces the loading placeholder with the final link in one operation