### PR TITLE
fix: use immutable update for comment vote state

### DIFF
--- a/ui/src/components/Comment/index.tsx
+++ b/ui/src/components/Comment/index.tsx
@@ -311,10 +311,13 @@ const Comment: FC<IProps> = ({ objectId, mode, commentId, children }) => {
         setComments(
           comments.map((item) => {
             if (item.comment_id === id) {
-              item.vote_count = is_cancel
-                ? item.vote_count - 1
-                : item.vote_count + 1;
-              item.is_vote = !is_cancel;
+              return {
+                ...item,
+                vote_count: is_cancel
+                  ? item.vote_count - 1
+                  : item.vote_count + 1,
+                is_vote: !is_cancel,
+              };
             }
             return item;
           }),


### PR DESCRIPTION
## What changed
- Replace direct object mutation with spread operator in `submitVoteComment` for immutable state update

## Why
- The current code directly mutates the `item` object inside `comments.map()`, which violates React's immutable update principle
- The child component `ActionBar` is wrapped with `React.memo`, direct mutation may prevent memo from detecting changes, causing potential rendering issues

## Before
```js
item.vote_count = is_cancel ? item.vote_count - 1 : item.vote_count + 1;
item.is_vote = !is_cancel;
return item;
```

## After
```js
return {
  ...item,
  vote_count: is_cancel ? item.vote_count - 1 : item.vote_count + 1,
  is_vote: !is_cancel,
};
```

## Testing
- [x] Vote / unvote on comments works correctly
- [x] Vote after pagination works correctly
- [x] Data is correct after page refresh