### PR TITLE
fix: add Gin recovery middleware to prevent connection drops on panic

### DIFF
--- a/internal/base/middleware/recovery.go
+++ b/internal/base/middleware/recovery.go
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package middleware
+
+import (
+	"net/http"
+	"runtime/debug"
+
+	"github.com/apache/answer/internal/base/handler"
+	"github.com/apache/answer/internal/base/reason"
+	"github.com/gin-gonic/gin"
+	"github.com/segmentfault/pacman/log"
+)
+
+// Recovery returns a middleware that recovers from panics in handlers,
+// logs the panic and stack trace, and returns a structured 500 JSON response
+// consistent with the rest of the codebase.
+func Recovery() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Errorf("panic recovered: %v\n%s", r, debug.Stack())
+				lang := handler.GetLangByCtx(c)
+				c.JSON(http.StatusInternalServerError,
+					handler.NewRespBody(http.StatusInternalServerError, reason.UnknownError).TrMsg(lang))
+				c.Abort()
+			}
+		}()
+		c.Next()
+	}
+}

--- a/internal/base/middleware/recovery_test.go
+++ b/internal/base/middleware/recovery_test.go
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestRecovery(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("recovers from panic and returns 500", func(t *testing.T) {
+		r := gin.New()
+		r.Use(Recovery())
+		r.GET("/panic", func(c *gin.Context) {
+			panic("test panic")
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/panic", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("expected status 500, got %d", w.Code)
+		}
+
+		var body map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("response body is not valid JSON: %v", err)
+		}
+
+		if body["reason"] == nil || body["reason"] == "" {
+			t.Fatal("expected non-empty reason field in response")
+		}
+	})
+
+	t.Run("does not affect normal requests", func(t *testing.T) {
+		r := gin.New()
+		r.Use(Recovery())
+		r.GET("/ok", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"status": "ok"})
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/ok", nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+
+		var body map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("response body is not valid JSON: %v", err)
+		}
+
+		if body["status"] != "ok" {
+			t.Fatalf("expected status 'ok', got %v", body["status"])
+		}
+	})
+}

--- a/internal/base/server/http.go
+++ b/internal/base/server/http.go
@@ -52,6 +52,7 @@ func NewHTTPServer(debug bool,
 		gin.SetMode(gin.ReleaseMode)
 	}
 	r := gin.New()
+	r.Use(middleware.Recovery())
 	r.Use(func(ctx *gin.Context) {
 		if strings.Contains(ctx.Request.URL.Path, "/chat/completions") {
 			return


### PR DESCRIPTION
## Problem

As described in #1536, the Gin engine was initialized via `gin.New()` without a recovery middleware. When a panic occurs in any handler or middleware, the Go runtime's `net/http` server recovers per-connection but closes the connection without writing any response body. The client sees a connection reset/EOF rather than a structured 500 response, and the panic is not logged through the project's logging facility.

## Solution

Added a `middleware.Recovery()` function that:
- Recovers from panics using `defer/recover()`
- Logs the panic message and full stack trace via `log.Errorf` + `debug.Stack()`
- Returns the standard error response using `handler.NewRespBody` + `TrMsg` with `reason.UnknownError`, staying consistent with how unknown errors are handled in `handler.HandleResponse`
- Is mounted as the **first** middleware in `http.go` (before brotli, language extraction, etc.) so it covers all subsequent middleware and handlers

## Testing

Added unit tests in `recovery_test.go` covering:
1. **Panic recovery**: A handler that panics returns a 500 with a non-empty `reason` field in the JSON body
2. **Normal request flow**: A handler that succeeds is not affected by the recovery middleware

```
$ go test ./internal/base/middleware/ -run TestRecovery -v
=== RUN   TestRecovery
=== RUN   TestRecovery/recovers_from_panic_and_returns_500
=== RUN   TestRecovery/does_not_affect_normal_requests
--- PASS: TestRecovery (0.00s)
    --- PASS: TestRecovery/recovers_from_panic_and_returns_500 (0.00s)
    --- PASS: TestRecovery/does_not_affect_normal_requests (0.00s)
PASS
```

Also verified with `go vet` — no issues. The full middleware and server packages build cleanly.

Closes #1536