### PR TITLE
feat: support custom domains for tags

### DIFF
--- a/i18n/en_US.yaml
+++ b/i18n/en_US.yaml
@@ -252,6 +252,10 @@ backend:
     tag:
       already_exist:
         other: Tag already exists.
+      domain_already_exist:
+        other: This domain is already bound to another tag.
+      domain_invalid:
+        other: Please enter a valid domain name.
       not_found:
         other: Tag not found.
       recommend_tag_not_found:
@@ -1034,6 +1038,12 @@ ui:
             empty: URL slug cannot be empty.
             range: URL slug up to 35 characters.
             character: URL slug contains unallowed character set.
+        domain:
+          label: Domain
+          desc: Optional domain that redirects to this tag.
+          placeholder: tag.example.com
+          msg:
+            invalid: Please enter a valid domain name.
         desc:
           label: Description
         revision:
@@ -2488,4 +2498,3 @@ ui:
     copy: Copy to clipboard
     copied: Copied
     external_content_warning: External images/media are not displayed.
-

--- a/i18n/zh_CN.yaml
+++ b/i18n/zh_CN.yaml
@@ -251,6 +251,10 @@ backend:
     tag:
       already_exist:
         other: 标签已存在。
+      domain_already_exist:
+        other: 此域名已绑定到其他标签。
+      domain_invalid:
+        other: 请输入有效的域名。
       not_found:
         other: 标签未找到。
       recommend_tag_not_found:
@@ -1021,6 +1025,12 @@ ui:
             empty: URL 固定链接不能为空。
             range: URL 固定链接不能超过 35 个字符。
             character: URL 固定链接包含非法字符。
+        domain:
+          label: 域名
+          desc: 可选。访问此域名时将跳转到当前标签。
+          placeholder: tag.example.com
+          msg:
+            invalid: 请输入有效的域名。
         desc:
           label: 描述
         revision:
@@ -2446,5 +2456,3 @@ ui:
     copy: 复制到剪贴板
     copied: 已复制
     external_content_warning: 外部图像/媒体未显示。
-
-

--- a/internal/base/reason/reason.go
+++ b/internal/base/reason/reason.go
@@ -78,6 +78,7 @@ const (
 	TagCannotUpdate                  = "error.tag.cannot_update"
 	TagIsUsedCannotDelete            = "error.tag.is_used_cannot_delete"
 	TagAlreadyExist                  = "error.tag.already_exist"
+	TagDomainAlreadyExists           = "error.tag.domain_already_exist"
 	TagMinCount                      = "error.tag.minimum_count"
 	RankFailToMeetTheCondition       = "error.rank.fail_to_meet_the_condition"
 	VoteRankFailToMeetTheCondition   = "error.rank.vote_fail_to_meet_the_condition"

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -136,6 +136,13 @@ func (tc *TemplateController) SiteInfo(ctx *gin.Context) *schema.TemplateSiteInf
 
 // Index question list
 func (tc *TemplateController) Index(ctx *gin.Context) {
+	if tagSlug, exists, err := tc.templateRenderController.GetTagSlugByDomain(ctx, ctx.Request.Host); err != nil {
+		log.Error(err)
+	} else if exists {
+		ctx.Redirect(http.StatusFound, tagDomainRedirectPath(ctx.Request.URL.Path, tagSlug))
+		return
+	}
+
 	req := &schema.QuestionPageReq{
 		OrderCond: "newest",
 	}
@@ -173,6 +180,11 @@ func (tc *TemplateController) Index(ctx *gin.Context) {
 		"path":        "questions",
 		"hotQuestion": hotQuestion,
 	})
+}
+
+func tagDomainRedirectPath(requestPath, tagSlug string) string {
+	basePath := strings.TrimSuffix(requestPath, "/")
+	return fmt.Sprintf("%s/tags/%s", basePath, url.PathEscape(tagSlug))
 }
 
 func (tc *TemplateController) QuestionList(ctx *gin.Context) {

--- a/internal/controller/template_controller_test.go
+++ b/internal/controller/template_controller_test.go
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package controller
+
+import "testing"
+
+func TestTagDomainRedirectPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		requestPath string
+		tagSlug     string
+		want        string
+	}{
+		{name: "root", requestPath: "/", tagSlug: "go", want: "/tags/go"},
+		{name: "base path", requestPath: "/answer", tagSlug: "go", want: "/answer/tags/go"},
+		{name: "base path trailing slash", requestPath: "/answer/", tagSlug: "go", want: "/answer/tags/go"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tagDomainRedirectPath(tt.requestPath, tt.tagSlug); got != tt.want {
+				t.Fatalf("tagDomainRedirectPath(%q, %q) = %q, want %q", tt.requestPath, tt.tagSlug, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/template_render/controller.go
+++ b/internal/controller/template_render/controller.go
@@ -20,6 +20,7 @@
 package templaterender
 
 import (
+	"context"
 	"math"
 
 	"github.com/apache/answer/internal/service/content"
@@ -46,6 +47,15 @@ type TemplateRenderController struct {
 	commentService  *comment.CommentService
 	siteInfoService siteinfo_common.SiteInfoCommonService
 	questionRepo    questioncommon.QuestionRepo
+}
+
+// GetTagSlugByDomain resolves a host name to its bound tag slug.
+func (q *TemplateRenderController) GetTagSlugByDomain(ctx context.Context, domain string) (string, bool, error) {
+	tagInfo, exist, err := q.tagService.GetTagByDomain(ctx, domain)
+	if err != nil || !exist {
+		return "", exist, err
+	}
+	return tagInfo.SlugName, true, nil
 }
 
 func NewTemplateRenderController(

--- a/internal/entity/tag_entity.go
+++ b/internal/entity/tag_entity.go
@@ -39,6 +39,7 @@ type Tag struct {
 	MainTagID       int64     `xorm:"not null default 0 BIGINT(20) main_tag_id"`
 	MainTagSlugName string    `xorm:"not null default '' VARCHAR(35) main_tag_slug_name"`
 	SlugName        string    `xorm:"not null default '' unique VARCHAR(35) slug_name"`
+	Domain          string    `xorm:"not null default '' VARCHAR(253) domain index"`
 	DisplayName     string    `xorm:"not null default '' VARCHAR(35) display_name"`
 	OriginalText    string    `xorm:"not null MEDIUMTEXT original_text"`
 	ParsedText      string    `xorm:"not null MEDIUMTEXT parsed_text"`

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -110,6 +110,7 @@ var migrations = []Migration{
 	NewMigration("v2.0.1", "change avatar type to text", updateAvatarType, false),
 	NewMigration("v2.0.2", "add reasoning content to ai conversation record", addAIConversationReasoningContent, false),
 	NewMigration("v2.0.3", "add require email verification login setting", addRequireEmailVerification, true),
+	NewMigration("v2.0.4", "add tag domain", addTagDomain, true),
 }
 
 func GetMigrations() []Migration {

--- a/internal/migrations/v35.go
+++ b/internal/migrations/v35.go
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/answer/internal/entity"
+	"xorm.io/xorm"
+)
+
+func addTagDomain(ctx context.Context, x *xorm.Engine) error {
+	if err := x.Context(ctx).Sync(new(entity.Tag)); err != nil {
+		return fmt.Errorf("sync tag table failed: %w", err)
+	}
+	return nil
+}

--- a/internal/repo/tag_common/tag_common_repo.go
+++ b/internal/repo/tag_common/tag_common_repo.go
@@ -76,6 +76,18 @@ func (tr *tagCommonRepo) GetTagBySlugName(ctx context.Context, slugName string) 
 	return
 }
 
+// GetTagByDomain returns the active tag bound to a domain.
+func (tr *tagCommonRepo) GetTagByDomain(ctx context.Context, domain string) (tagInfo *entity.Tag, exist bool, err error) {
+	tagInfo = &entity.Tag{}
+	session := tr.data.DB.Context(ctx).Where("LOWER(domain) = ?", domain)
+	session.Where(builder.Eq{"status": entity.TagStatusAvailable})
+	exist, err = session.Get(tagInfo)
+	if err != nil {
+		return nil, false, errors.InternalServer(reason.DatabaseError).WithError(err).WithStack()
+	}
+	return
+}
+
 // GetTagListByName get tag list all like name
 func (tr *tagCommonRepo) GetTagListByName(ctx context.Context, name string, recommend, reserved bool) (tagList []*entity.Tag, err error) {
 	cond := &entity.Tag{}

--- a/internal/schema/tag_schema.go
+++ b/internal/schema/tag_schema.go
@@ -20,6 +20,7 @@
 package schema
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/apache/answer/internal/base/validator"
@@ -74,6 +75,7 @@ type GetTagResp struct {
 	CreatedAt     int64                     `json:"created_at"`
 	UpdatedAt     int64                     `json:"updated_at"`
 	SlugName      string                    `json:"slug_name"`
+	Domain        string                    `json:"domain"`
 	DisplayName   string                    `json:"display_name"`
 	Excerpt       string                    `json:"excerpt"`
 	OriginalText  string                    `json:"original_text"`
@@ -105,6 +107,8 @@ type GetTagPageResp struct {
 	TagID string `json:"tag_id"`
 	// slug_name
 	SlugName string `json:"slug_name"`
+	// domain
+	Domain string `json:"domain"`
 	// display_name
 	DisplayName string `json:"display_name"`
 	// excerpt
@@ -168,6 +172,8 @@ type RemoveTagReq struct {
 type AddTagReq struct {
 	// slug_name
 	SlugName string `validate:"required,gt=0,lte=35" json:"slug_name"`
+	// domain binds the tag to a host name
+	Domain string `json:"domain"`
 	// display_name
 	DisplayName string `validate:"required,gt=0,lte=35" json:"display_name"`
 	// original text
@@ -181,6 +187,9 @@ type AddTagReq struct {
 func (req *AddTagReq) Check() (errFields []*validator.FormErrorField, err error) {
 	req.ParsedText = converter.Markdown2HTML(req.OriginalText)
 	req.SlugName = strings.ToLower(req.SlugName)
+	if req.Domain, err = normalizeTagDomain(req.Domain); err != nil {
+		return []*validator.FormErrorField{{ErrorField: "domain", ErrorMsg: "error.tag.domain_invalid"}}, err
+	}
 	return nil, nil
 }
 
@@ -195,6 +204,8 @@ type UpdateTagReq struct {
 	TagID string `validate:"required" json:"tag_id"`
 	// slug_name
 	SlugName string `validate:"omitempty,gt=0,lte=35" json:"slug_name"`
+	// domain binds the tag to a host name
+	Domain string `json:"domain"`
 	// display_name
 	DisplayName string `validate:"omitempty,gt=0,lte=35" json:"display_name"`
 	// original text
@@ -210,7 +221,31 @@ type UpdateTagReq struct {
 
 func (r *UpdateTagReq) Check() (errFields []*validator.FormErrorField, err error) {
 	r.ParsedText = converter.Markdown2HTML(r.OriginalText)
+	if r.Domain, err = normalizeTagDomain(r.Domain); err != nil {
+		return []*validator.FormErrorField{{ErrorField: "domain", ErrorMsg: "error.tag.domain_invalid"}}, err
+	}
 	return nil, nil
+}
+
+func normalizeTagDomain(domain string) (string, error) {
+	domain = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(domain)), ".")
+	if domain == "" {
+		return "", nil
+	}
+	if len(domain) > 253 || strings.ContainsAny(domain, "/?#:@") {
+		return "", errors.New("invalid tag domain")
+	}
+	for _, label := range strings.Split(domain, ".") {
+		if len(label) == 0 || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return "", errors.New("invalid tag domain")
+		}
+		for _, char := range label {
+			if (char < 'a' || char > 'z') && (char < '0' || char > '9') && char != '-' {
+				return "", errors.New("invalid tag domain")
+			}
+		}
+	}
+	return domain, nil
 }
 
 // RecoverTagReq update tag request

--- a/internal/schema/tag_schema_test.go
+++ b/internal/schema/tag_schema_test.go
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package schema
+
+import "testing"
+
+func TestNormalizeTagDomain(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty", input: "", want: ""},
+		{name: "normalizes case and trailing dot", input: "Tag.Example.COM.", want: "tag.example.com"},
+		{name: "allows localhost", input: "localhost", want: "localhost"},
+		{name: "rejects url", input: "https://tag.example.com", wantErr: true},
+		{name: "rejects invalid label", input: "tag..example.com", wantErr: true},
+		{name: "rejects underscore", input: "tag_name.example.com", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeTagDomain(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("normalizeTagDomain(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("normalizeTagDomain(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/service/content/revision_service.go
+++ b/internal/service/content/revision_service.go
@@ -485,6 +485,7 @@ func (rs *RevisionService) parseItem(ctx context.Context, item *schema.GetRevisi
 			CreatedAt:     tag.CreatedAt.Unix(),
 			UpdatedAt:     tag.UpdatedAt.Unix(),
 			SlugName:      tag.SlugName,
+			Domain:        tag.Domain,
 			DisplayName:   tag.DisplayName,
 			OriginalText:  tag.OriginalText,
 			ParsedText:    tag.ParsedText,

--- a/internal/service/tag/tag_service.go
+++ b/internal/service/tag/tag_service.go
@@ -176,6 +176,7 @@ func (ts *TagService) GetTagInfo(ctx context.Context, req *schema.GetTagInfoReq)
 	resp.CreatedAt = tagInfo.CreatedAt.Unix()
 	resp.UpdatedAt = tagInfo.UpdatedAt.Unix()
 	resp.SlugName = tagInfo.SlugName
+	resp.Domain = tagInfo.Domain
 	resp.DisplayName = tagInfo.DisplayName
 	resp.OriginalText = tagInfo.OriginalText
 	resp.ParsedText = tagInfo.ParsedText
@@ -189,6 +190,11 @@ func (ts *TagService) GetTagInfo(ctx context.Context, req *schema.GetTagInfoReq)
 	resp.MemberActions = permission.GetTagPermission(ctx, tagInfo.Status, req.CanEdit, req.CanDelete, req.CanMerge, req.CanRecover)
 	resp.GetExcerpt()
 	return resp, nil
+}
+
+// GetTagByDomain returns the active tag bound to a host name.
+func (ts *TagService) GetTagByDomain(ctx context.Context, domain string) (*entity.Tag, bool, error) {
+	return ts.tagCommonService.GetTagByDomain(ctx, domain)
 }
 
 // GetTagsBySlugName get tags by slug name
@@ -418,6 +424,7 @@ func (ts *TagService) GetTagWithPage(ctx context.Context, req *schema.GetTagWith
 		item := &schema.GetTagPageResp{
 			TagID:         tag.ID,
 			SlugName:      tag.SlugName,
+			Domain:        tag.Domain,
 			Description:   htmltext.FetchExcerpt(tag.ParsedText, "...", 240),
 			DisplayName:   tag.DisplayName,
 			OriginalText:  tag.OriginalText,

--- a/internal/service/tag_common/tag_common.go
+++ b/internal/service/tag_common/tag_common.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"sort"
 	"strings"
 
@@ -45,6 +46,7 @@ type TagCommonRepo interface {
 	AddTagList(ctx context.Context, tagList []*entity.Tag) (err error)
 	GetTagListByIDs(ctx context.Context, ids []string) (tagList []*entity.Tag, err error)
 	GetTagBySlugName(ctx context.Context, slugName string) (tagInfo *entity.Tag, exist bool, err error)
+	GetTagByDomain(ctx context.Context, domain string) (tagInfo *entity.Tag, exist bool, err error)
 	GetTagListByName(ctx context.Context, name string, recommend, reserved bool) (tagList []*entity.Tag, err error)
 	GetTagListByNames(ctx context.Context, names []string) (tagList []*entity.Tag, err error)
 	GetTagByID(ctx context.Context, tagID string, includeDeleted bool) (tag *entity.Tag, exist bool, err error)
@@ -347,10 +349,20 @@ func (ts *TagCommonService) AddTag(ctx context.Context, req *schema.AddTagReq) (
 	if exist {
 		return nil, errors.BadRequest(reason.TagAlreadyExist)
 	}
+	if req.Domain != "" {
+		_, exist, err = ts.GetTagByDomain(ctx, req.Domain)
+		if err != nil {
+			return nil, err
+		}
+		if exist {
+			return nil, errors.BadRequest(reason.TagDomainAlreadyExists)
+		}
+	}
 	slugName := strings.ReplaceAll(req.SlugName, " ", "-")
 	slugName = strings.ToLower(slugName)
 	tagInfo := &entity.Tag{
 		SlugName:     slugName,
+		Domain:       req.Domain,
 		DisplayName:  req.DisplayName,
 		OriginalText: req.OriginalText,
 		ParsedText:   req.ParsedText,
@@ -412,6 +424,23 @@ func (ts *TagCommonService) GetTagBySlugName(ctx context.Context, slugName strin
 	}
 	ts.tagFormatRecommendAndReserved(ctx, tag)
 	return
+}
+
+// GetTagByDomain returns the active tag bound to a host name.
+func (ts *TagCommonService) GetTagByDomain(ctx context.Context, domain string) (tag *entity.Tag, exist bool, err error) {
+	domain = normalizeTagDomain(domain)
+	if domain == "" {
+		return nil, false, nil
+	}
+	return ts.tagCommonRepo.GetTagByDomain(ctx, domain)
+}
+
+func normalizeTagDomain(domain string) string {
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	if host, _, err := net.SplitHostPort(domain); err == nil {
+		domain = host
+	}
+	return strings.TrimSuffix(domain, ".")
 }
 
 // GetTagListByIDs get object tag
@@ -889,11 +918,22 @@ func (ts *TagCommonService) UpdateTag(ctx context.Context, req *schema.UpdateTag
 	// If the content is the same, ignore it
 	if tagInfo.OriginalText == req.OriginalText &&
 		tagInfo.DisplayName == req.DisplayName &&
-		tagInfo.SlugName == slugName {
+		tagInfo.SlugName == slugName &&
+		tagInfo.Domain == req.Domain {
 		return nil
+	}
+	if req.Domain != "" {
+		domainTag, domainExists, err := ts.GetTagByDomain(ctx, req.Domain)
+		if err != nil {
+			return err
+		}
+		if domainExists && domainTag.ID != tagInfo.ID {
+			return errors.BadRequest(reason.TagDomainAlreadyExists)
+		}
 	}
 
 	tagInfo.SlugName = slugName
+	tagInfo.Domain = req.Domain
 	tagInfo.DisplayName = req.DisplayName
 	tagInfo.OriginalText = req.OriginalText
 	tagInfo.ParsedText = req.ParsedText

--- a/internal/service/tag_common/tag_common_test.go
+++ b/internal/service/tag_common/tag_common_test.go
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package tag_common
+
+import "testing"
+
+func TestNormalizeTagDomain(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "plain", input: "Tag.Example.COM", want: "tag.example.com"},
+		{name: "trailing dot", input: "tag.example.com.", want: "tag.example.com"},
+		{name: "port", input: "tag.example.com:8080", want: "tag.example.com"},
+		{name: "port and trailing dot", input: "tag.example.com.:443", want: "tag.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeTagDomain(tt.input); got != tt.want {
+				t.Fatalf("normalizeTagDomain(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/ui/src/common/interface.ts
+++ b/ui/src/common/interface.ts
@@ -66,6 +66,7 @@ export interface SynonymsTag extends Tag {
 
 export interface TagInfo extends TagBase {
   tag_id: string;
+  domain?: string;
   original_text: string;
   parsed_text: string;
   follow_count: number;

--- a/ui/src/pages/Tags/Create/index.tsx
+++ b/ui/src/pages/Tags/Create/index.tsx
@@ -35,6 +35,7 @@ import { TAG_SLUG_NAME_MAX_LENGTH } from '@/common/constants';
 interface FormDataItem {
   displayName: Type.FormValue<string>;
   slugName: Type.FormValue<string>;
+  domain: Type.FormValue<string>;
   description: Type.FormValue<string>;
 }
 
@@ -46,6 +47,11 @@ const Index = () => {
       errorMsg: '',
     },
     slugName: {
+      value: '',
+      isInvalid: false,
+      errorMsg: '',
+    },
+    domain: {
       value: '',
       isInvalid: false,
       errorMsg: '',
@@ -74,10 +80,16 @@ const Index = () => {
   });
 
   useEffect(() => {
-    const { displayName, slugName, description } = formData;
+    const {
+      displayName,
+      slugName,
+      domain: currentDomain,
+      description,
+    } = formData;
     const {
       displayName: display_name,
       slugName: slug_name,
+      domain: initialDomain,
       description: original_text,
     } = immData;
     if (!display_name || !slug_name || !original_text) {
@@ -87,6 +99,7 @@ const Index = () => {
     if (
       display_name.value !== displayName.value ||
       slug_name.value !== slugName.value ||
+      initialDomain.value !== currentDomain.value ||
       original_text.value !== description.value
     ) {
       setContentChanged(true);
@@ -96,6 +109,7 @@ const Index = () => {
   }, [
     formData.displayName.value,
     formData.slugName.value,
+    formData.domain.value,
     formData.description.value,
   ]);
 
@@ -182,6 +196,7 @@ const Index = () => {
     const params = {
       display_name: formData.displayName.value,
       slug_name: formData.slugName.value,
+      domain: formData.domain.value,
       original_text: formData.description.value,
     };
     createTag(params)
@@ -226,6 +241,17 @@ const Index = () => {
     });
   };
 
+  const handleDomainChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({
+      ...formData,
+      domain: {
+        ...formData.domain,
+        value: e.currentTarget.value,
+        isInvalid: false,
+      },
+    });
+  };
+
   usePageTags({
     title: t('create_tag', { keyPrefix: 'page_title' }),
   });
@@ -262,6 +288,22 @@ const Index = () => {
               <Form.Text as="div">{t('form.fields.slug_name.desc')}</Form.Text>
               <Form.Control.Feedback type="invalid">
                 {formData.slugName.errorMsg}
+              </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group controlId="domain" className="mb-3">
+              <Form.Label>{t('form.fields.domain.label')}</Form.Label>
+              <Form.Control
+                type="text"
+                value={formData.domain.value}
+                isInvalid={formData.domain.isInvalid}
+                disabled={role_id !== 2 && role_id !== 3}
+                onChange={handleDomainChange}
+                placeholder={t('form.fields.domain.placeholder')}
+              />
+              <Form.Text as="div">{t('form.fields.domain.desc')}</Form.Text>
+              <Form.Control.Feedback type="invalid">
+                {formData.domain.errorMsg}
               </Form.Control.Feedback>
             </Form.Group>
 

--- a/ui/src/pages/Tags/Edit/index.tsx
+++ b/ui/src/pages/Tags/Edit/index.tsx
@@ -35,6 +35,7 @@ import { useTagInfo, modifyTag, useQueryRevisions } from '@/services';
 interface FormDataItem {
   displayName: Type.FormValue<string>;
   slugName: Type.FormValue<string>;
+  domain: Type.FormValue<string>;
   description: Type.FormValue<string>;
   editSummary: Type.FormValue<string>;
 }
@@ -45,6 +46,11 @@ const initFormData = {
     errorMsg: '',
   },
   slugName: {
+    value: '',
+    isInvalid: false,
+    errorMsg: '',
+  },
+  domain: {
     value: '',
     isInvalid: false,
     errorMsg: '',
@@ -86,22 +92,31 @@ const Index = () => {
   useEffect(() => {
     initFormData.displayName.value = data?.display_name || '';
     initFormData.slugName.value = data?.slug_name || '';
+    initFormData.domain.value = data?.domain || '';
     initFormData.description.value = data?.original_text || '';
     setFormData(initFormData);
     setImmData(initFormData);
   }, [data]);
 
   useEffect(() => {
-    const { displayName, slugName, description, editSummary } = formData;
+    const {
+      displayName,
+      slugName,
+      domain: currentDomain,
+      description,
+      editSummary,
+    } = formData;
     const {
       displayName: display_name,
       slugName: slug_name,
+      domain: initialDomain,
       description: original_text,
     } = immData;
 
     if (
       display_name.value !== displayName.value ||
       slug_name.value !== slugName.value ||
+      initialDomain.value !== currentDomain.value ||
       original_text.value !== description.value ||
       editSummary.value
     ) {
@@ -112,6 +127,7 @@ const Index = () => {
   }, [
     formData.displayName.value,
     formData.slugName.value,
+    formData.domain.value,
     formData.description.value,
     formData.editSummary.value,
   ]);
@@ -196,6 +212,7 @@ const Index = () => {
     const params = {
       display_name: formData.displayName.value,
       slug_name: formData.slugName.value,
+      domain: formData.domain.value,
       original_text: formData.description.value,
       parsed_text: editorRef.current.getHtml(),
       tag_id: data?.tag_id,
@@ -215,6 +232,7 @@ const Index = () => {
     formData.description.value = revision.content.original_text;
     formData.displayName.value = revision.content.display_name;
     formData.slugName.value = revision.content.slug_name;
+    formData.domain.value = revision.content.domain || '';
     setImmData({ ...formData });
     setFormData({ ...formData });
   };
@@ -237,6 +255,13 @@ const Index = () => {
     setFormData({
       ...formData,
       slugName: { ...formData.slugName, value: e.currentTarget.value },
+    });
+  };
+
+  const handleDomainChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({
+      ...formData,
+      domain: { ...formData.domain, value: e.currentTarget.value },
     });
   };
 
@@ -306,6 +331,27 @@ const Index = () => {
               </Form.Text>
               <Form.Control.Feedback type="invalid">
                 {formData.slugName.errorMsg}
+              </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group controlId="domain" className="mb-3">
+              <Form.Label>
+                {t('form.fields.domain.label', { keyPrefix: 'tag_modal' })}
+              </Form.Label>
+              <Form.Control
+                value={formData.domain.value}
+                isInvalid={formData.domain.isInvalid}
+                disabled={role_id !== 2 && role_id !== 3}
+                onChange={handleDomainChange}
+                placeholder={t('form.fields.domain.placeholder', {
+                  keyPrefix: 'tag_modal',
+                })}
+              />
+              <Form.Text as="div">
+                {t('form.fields.domain.desc', { keyPrefix: 'tag_modal' })}
+              </Form.Text>
+              <Form.Control.Feedback type="invalid">
+                {formData.domain.errorMsg}
               </Form.Control.Feedback>
             </Form.Group>
 


### PR DESCRIPTION
## Proposed Changes

- Add an optional custom domain to tags, including normalization, validation, duplicate protection, and a database migration.
- Redirect requests to the root of a bound domain to the corresponding `/tags/{slug}` page while preserving configured base paths.
- Add domain fields to the tag create/edit UI, API responses, revisions, and English/Chinese translations.
- Add focused tests for domain validation, request host normalization, and redirect path construction.

The current plugin APIs can register plugin API endpoints and client-side routes, but they cannot intercept the top-level request host or resolve tag data during template routing. This behavior therefore needs to live in the core routing and tag model.

## Validation

- `go test ./...`
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/common/interface.ts src/pages/Tags/Create/index.tsx src/pages/Tags/Edit/index.tsx`
- `pnpm build`
